### PR TITLE
Fix logging pattern

### DIFF
--- a/src/hutch_bunny/cli.py
+++ b/src/hutch_bunny/cli.py
@@ -1,14 +1,12 @@
 import json
 
-from hutch_bunny.core.obfuscation import low_number_suppression
 from hutch_bunny.core.results_modifiers import (
     get_results_modifiers_from_str,
-    results_modifiers,
 )
 from hutch_bunny.core.execute_query import execute_query
 from hutch_bunny.core.rquest_dto.result import RquestResult
 from hutch_bunny.core.parser import parser
-from hutch_bunny.core.logger import logger
+from hutch_bunny.core.logger import configure_logger, logger
 from hutch_bunny.core.setting_database import setting_database
 from hutch_bunny.core.settings import get_settings, Settings
 from importlib.metadata import version
@@ -36,11 +34,12 @@ def save_to_output(result: RquestResult, destination: str) -> None:
 
 
 def main() -> None:
-    logger.info(f"Starting Bunny version: {version('hutch_bunny')}")
     settings: Settings = get_settings()
+    configure_logger(settings)
+    logger.info(f"Starting Bunny version: {version('hutch_bunny')}")
     logger.debug("Settings: %s", settings.safe_model_dump())
     # Setting database connection
-    db_manager = setting_database(logger=logger)
+    db_manager = setting_database()
     # Bunny passed args.
     args = parser.parse_args()
 
@@ -51,9 +50,7 @@ def main() -> None:
         args.results_modifiers
     )
 
-    result = execute_query(
-        query_dict, results_modifier, logger=logger, db_manager=db_manager
-    )
+    result = execute_query(query_dict, results_modifier, db_manager=db_manager)
     logger.debug(f"Results: {result.to_dict()}")
     save_to_output(result, args.output)
     logger.info(f"Saved results to {args.output}")

--- a/src/hutch_bunny/core/execute_query.py
+++ b/src/hutch_bunny/core/execute_query.py
@@ -1,17 +1,13 @@
-from typing import Dict, List
-from logging import Logger
+from typing import Dict
+from hutch_bunny.core.logger import logger
 from hutch_bunny.core.solvers import query_solvers
 from hutch_bunny.core.rquest_dto.query import AvailabilityQuery, DistributionQuery
-from hutch_bunny.core.obfuscation import (
-    apply_filters,
-)
 from hutch_bunny.core.rquest_dto.result import RquestResult
 
 
 def execute_query(
     query_dict: Dict,
     results_modifier: list[dict],
-    logger: Logger,
     db_manager,
 ) -> RquestResult:
     """

--- a/src/hutch_bunny/core/logger.py
+++ b/src/hutch_bunny/core/logger.py
@@ -1,16 +1,25 @@
 import logging
-from hutch_bunny.core.settings import get_settings
 import sys
+from logging import Logger
+from hutch_bunny.core.settings import Settings
 
-settings = get_settings()
+def setup_logger(settings: Settings) -> Logger:
+    """
+    Sets up a logger with the given settings.
 
-logger = logging.getLogger(settings.LOGGER_NAME)
-LOG_FORMAT = logging.Formatter(
-    settings.MSG_FORMAT,
-    datefmt=settings.DATE_FORMAT,
-)
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setFormatter(LOG_FORMAT)
-logger = logging.getLogger(settings.LOGGER_NAME)
-logger.setLevel(settings.LOGGER_LEVEL)
-logger.addHandler(console_handler)
+    Args:
+        settings (Settings): The settings to use for the logger.
+
+    Returns:
+        Logger: The logger.
+    """
+    logger = logging.getLogger(settings.LOGGER_NAME)
+    LOG_FORMAT = logging.Formatter(
+        settings.MSG_FORMAT,
+        datefmt=settings.DATE_FORMAT,
+    )
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(LOG_FORMAT)
+    logger.setLevel(settings.LOGGER_LEVEL)
+    logger.addHandler(console_handler)
+    return logger

--- a/src/hutch_bunny/core/logger.py
+++ b/src/hutch_bunny/core/logger.py
@@ -1,25 +1,12 @@
 import logging
-import sys
-from logging import Logger
-from hutch_bunny.core.settings import Settings
 
-def setup_logger(settings: Settings) -> Logger:
-    """
-    Sets up a logger with the given settings.
+logger = logging.getLogger("hutch_bunny")
 
-    Args:
-        settings (Settings): The settings to use for the logger.
 
-    Returns:
-        Logger: The logger.
-    """
-    logger = logging.getLogger(settings.LOGGER_NAME)
-    LOG_FORMAT = logging.Formatter(
-        settings.MSG_FORMAT,
-        datefmt=settings.DATE_FORMAT,
-    )
-    console_handler = logging.StreamHandler(sys.stdout)
+def configure_logger(settings) -> None:
+    LOG_FORMAT = logging.Formatter(settings.MSG_FORMAT, datefmt=settings.DATE_FORMAT)
+    console_handler = logging.StreamHandler()
     console_handler.setFormatter(LOG_FORMAT)
+
     logger.setLevel(settings.LOGGER_LEVEL)
     logger.addHandler(console_handler)
-    return logger

--- a/src/hutch_bunny/core/setting_database.py
+++ b/src/hutch_bunny/core/setting_database.py
@@ -1,4 +1,4 @@
-from logging import Logger
+from hutch_bunny.core.logger import logger
 from os import environ
 from hutch_bunny.core.db_manager import SyncDBManager, TrinoDBManager
 
@@ -24,7 +24,7 @@ def expand_short_drivers(drivername: str):
     return drivername
 
 
-def setting_database(logger: Logger) -> SyncDBManager | TrinoDBManager:
+def setting_database() -> SyncDBManager | TrinoDBManager:
     logger.info("Connecting to database...")
 
     # Trino has some different settings / defaults comapred with SQLAlchemy

--- a/src/hutch_bunny/core/upstream/polling_service.py
+++ b/src/hutch_bunny/core/upstream/polling_service.py
@@ -1,4 +1,4 @@
-from logging import Logger
+from hutch_bunny.core.logger import logger
 import time
 from typing import Callable
 import requests
@@ -16,7 +16,6 @@ class PollingService:
         client: TaskApiClient,
         task_handler: Callable,
         settings: DaemonSettings,
-        logger: Logger,
     ) -> None:
         """
         Initializes the PollingService.
@@ -33,7 +32,6 @@ class PollingService:
         self.client = client
         self.task_handler = task_handler
         self.settings = settings
-        self.logger = logger
         self.polling_endpoint = self._construct_polling_endpoint()
 
     def _construct_polling_endpoint(self) -> str:
@@ -78,7 +76,7 @@ class PollingService:
         polling_interval = self.settings.POLLING_INTERVAL
         iteration = 0
 
-        self.logger.info("Polling for tasks...")
+        logger.info("Polling for tasks...")
         while True:
             if max_iterations is not None and iteration >= max_iterations:
                 break
@@ -87,19 +85,19 @@ class PollingService:
                 response.raise_for_status()
 
                 if response.status_code == 200:
-                    self.logger.info("Task received. Resolving...")
-                    self.logger.debug(f"Task: {response.json()}")
+                    logger.info("Task received. Resolving...")
+                    logger.debug(f"Task: {response.json()}")
                     task_data = response.json()
                     self.task_handler(task_data)
 
                 elif response.status_code == 204:
-                    self.logger.debug("No task found. Looking for task...")
+                    logger.debug("No task found. Looking for task...")
                 else:
-                    self.logger.info(f"Got http status code: {response.status_code}")
+                    logger.info(f"Got http status code: {response.status_code}")
 
                 backoff_time = self.settings.INITIAL_BACKOFF
             except requests.exceptions.RequestException as e:
-                self.logger.error(f"Network error occurred: {e}")
+                logger.error(f"Network error occurred: {e}")
                 # Exponential backoff
                 time.sleep(backoff_time)
                 backoff_time = min(backoff_time * 2, max_backoff_time)

--- a/src/hutch_bunny/core/upstream/task_api_client.py
+++ b/src/hutch_bunny/core/upstream/task_api_client.py
@@ -1,4 +1,4 @@
-from logging import Logger
+from hutch_bunny.core.logger import logger
 import time
 from requests.models import Response
 from enum import Enum
@@ -21,12 +21,10 @@ class TaskApiClient:
     def __init__(
         self,
         settings: DaemonSettings,
-        logger: Logger,
     ):
         self.base_url = settings.TASK_API_BASE_URL
         self.username = settings.TASK_API_USERNAME
         self.password = settings.TASK_API_PASSWORD
-        self.logger = logger
 
     def request(
         self, method: SupportedMethod, url: str, data: Optional[dict] = None, **kwargs
@@ -43,7 +41,7 @@ class TaskApiClient:
         Returns:
             Response: The response object returned by the requests library.
         """
-        self.logger.debug(
+        logger.debug(
             "Sending %s request to %s with data %s and kwargs %s"
             % (method.value, url, data, kwargs)
         )
@@ -51,8 +49,8 @@ class TaskApiClient:
         response = requests.request(
             method=method.value, url=url, json=data, auth=basicAuth, **kwargs
         )
-        self.logger.debug("Response Status: %s", response.status_code)
-        self.logger.debug("Response Text: %s", response.text)
+        logger.debug("Response Status: %s", response.status_code)
+        logger.debug("Response Text: %s", response.text)
         return response
 
     def post(
@@ -107,15 +105,15 @@ class TaskApiClient:
                     200 <= response.status_code < 300
                     or 400 <= response.status_code < 500
                 ):
-                    self.logger.info("Task resolved.")
-                    self.logger.debug(f"Response status: {response.status_code}")
-                    self.logger.debug(f"Response: {response.text}")
+                    logger.info("Task resolved.")
+                    logger.debug(f"Response status: {response.status_code}")
+                    logger.debug(f"Response: {response.text}")
                     break
                 else:
-                    self.logger.warning(
+                    logger.warning(
                         f"Failed to post to {return_endpoint} at {time.time()}. Trying again..."
                     )
                     time.sleep(5)
             except requests.exceptions.RequestException as e:
-                self.logger.error(f"Network error occurred while posting results: {e}")
+                logger.error(f"Network error occurred while posting results: {e}")
                 time.sleep(5)

--- a/src/hutch_bunny/core/upstream/task_handler.py
+++ b/src/hutch_bunny/core/upstream/task_handler.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from hutch_bunny.core.db_manager import BaseDBManager
 from hutch_bunny.core.settings import DaemonSettings
 from hutch_bunny.core.execute_query import execute_query
@@ -10,7 +9,6 @@ def handle_task(
     task_data: dict,
     db_manager: BaseDBManager,
     settings: DaemonSettings,
-    logger: Logger,
     task_api_client: TaskApiClient,
 ) -> None:
     """
@@ -20,7 +18,6 @@ def handle_task(
         task_data (dict): The task data to execute the query on.
         db_manager (BaseDBManager): The database manager to use to execute the query.
         settings (DaemonSettings): The settings to use to execute the query.
-        logger (Logger): The logger to use to log messages.
         task_api_client (TaskApiClient): The task API client to use to send the results.
 
     Returns:
@@ -35,7 +32,6 @@ def handle_task(
     result = execute_query(
         task_data,
         result_modifier,
-        logger=logger,
         db_manager=db_manager,
     )
     task_api_client.send_results(result)

--- a/src/hutch_bunny/daemon.py
+++ b/src/hutch_bunny/daemon.py
@@ -1,6 +1,6 @@
 from hutch_bunny.core.settings import get_settings, DaemonSettings
 from hutch_bunny.core.upstream.task_api_client import TaskApiClient
-from hutch_bunny.core.logger import setup_logger
+from hutch_bunny.core.logger import configure_logger, logger
 from hutch_bunny.core.setting_database import setting_database
 from hutch_bunny.core.upstream.polling_service import PollingService
 from importlib.metadata import version
@@ -12,19 +12,18 @@ def main() -> None:
     Main function to start the daemon process.
     """
     settings: DaemonSettings = get_settings(daemon=True)
-    logger = setup_logger(settings)
+    configure_logger(settings)
     logger.info(f"Starting Bunny version {version('hutch_bunny')} ")
     logger.debug("Settings: %s", settings.safe_model_dump())
 
     # Setting database connection
-    db_manager = setting_database(logger=logger)
+    db_manager = setting_database()
 
-    client = TaskApiClient(settings=settings, logger=logger)
+    client = TaskApiClient(settings=settings)
     polling_service = PollingService(
         client,
-        lambda task_data: handle_task(task_data, db_manager, settings, logger, client),
+        lambda task_data: handle_task(task_data, db_manager, settings, client),
         settings,
-        logger,
     )
     polling_service.poll_for_tasks()
 

--- a/src/hutch_bunny/daemon.py
+++ b/src/hutch_bunny/daemon.py
@@ -1,7 +1,6 @@
 from hutch_bunny.core.settings import get_settings, DaemonSettings
-from hutch_bunny.core.db_manager import SyncDBManager
 from hutch_bunny.core.upstream.task_api_client import TaskApiClient
-from hutch_bunny.core.logger import logger
+from hutch_bunny.core.logger import setup_logger
 from hutch_bunny.core.setting_database import setting_database
 from hutch_bunny.core.upstream.polling_service import PollingService
 from importlib.metadata import version
@@ -12,14 +11,15 @@ def main() -> None:
     """
     Main function to start the daemon process.
     """
-    logger.info(f"Starting Bunny version {version('hutch_bunny')} ")
     settings: DaemonSettings = get_settings(daemon=True)
+    logger = setup_logger(settings)
+    logger.info(f"Starting Bunny version {version('hutch_bunny')} ")
     logger.debug("Settings: %s", settings.safe_model_dump())
 
     # Setting database connection
     db_manager = setting_database(logger=logger)
 
-    client = TaskApiClient()
+    client = TaskApiClient(settings=settings, logger=logger)
     polling_service = PollingService(
         client,
         lambda task_data: handle_task(task_data, db_manager, settings, logger, client),

--- a/tests/test_logging_env.py
+++ b/tests/test_logging_env.py
@@ -1,27 +1,27 @@
 import pytest
 import os
 from importlib import reload
+import logging
 
 import hutch_bunny.core.logger
 import hutch_bunny.core.settings
 
 
-def test_set_level():
+def test_configure_logger():
     # Test INFO level
     os.environ["BUNNY_LOGGER_LEVEL"] = "INFO"
     reload(hutch_bunny.core.settings)
     settings = hutch_bunny.core.settings.get_settings()
-    assert settings.LOGGER_LEVEL == "INFO"
-    logger = hutch_bunny.core.logger.setup_logger(settings)
-    assert logger.level == 20
+    hutch_bunny.core.logger.configure_logger(settings)
+    logger = logging.getLogger("hutch_bunny")
+    assert logger.level == logging.INFO
 
     # Test DEBUG level
-    os.environ["BUNNY_LOGGER_LEVEL"] = "DEBUG" 
+    os.environ["BUNNY_LOGGER_LEVEL"] = "DEBUG"
     reload(hutch_bunny.core.settings)
     settings = hutch_bunny.core.settings.get_settings()
-    assert settings.LOGGER_LEVEL == "DEBUG"
-    logger = hutch_bunny.core.logger.setup_logger(settings)
-    assert logger.level == 10
+    hutch_bunny.core.logger.configure_logger(settings)
+    assert logger.level == logging.DEBUG
 
     # Test invalid level raises validation error
     os.environ["BUNNY_LOGGER_LEVEL"] = "FLOPPSY"

--- a/tests/test_logging_env.py
+++ b/tests/test_logging_env.py
@@ -12,16 +12,16 @@ def test_set_level():
     reload(hutch_bunny.core.settings)
     settings = hutch_bunny.core.settings.get_settings()
     assert settings.LOGGER_LEVEL == "INFO"
-    reload(hutch_bunny.core.logger)
-    assert hutch_bunny.core.logger.logger.level == 20
+    logger = hutch_bunny.core.logger.setup_logger(settings)
+    assert logger.level == 20
 
     # Test DEBUG level
     os.environ["BUNNY_LOGGER_LEVEL"] = "DEBUG" 
     reload(hutch_bunny.core.settings)
     settings = hutch_bunny.core.settings.get_settings()
     assert settings.LOGGER_LEVEL == "DEBUG"
-    reload(hutch_bunny.core.logger)
-    assert hutch_bunny.core.logger.logger.level == 10
+    logger = hutch_bunny.core.logger.setup_logger(settings)
+    assert logger.level == 10
 
     # Test invalid level raises validation error
     os.environ["BUNNY_LOGGER_LEVEL"] = "FLOPPSY"

--- a/tests/upstream/test_polling_service.py
+++ b/tests/upstream/test_polling_service.py
@@ -33,7 +33,6 @@ def mock_task_handler():
     return Mock()
 
 
-
 def test_poll_for_tasks_success(
     mock_logger, mock_settings, mock_client, mock_task_handler
 ):
@@ -41,9 +40,7 @@ def test_poll_for_tasks_success(
     mock_client.get.return_value.status_code = 200
     mock_client.get.return_value.json.return_value = {"task": "data"}
 
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     with patch("time.sleep", return_value=None):  # To speed up the test
@@ -60,9 +57,7 @@ def test_poll_for_tasks_no_task(
     # Arrange
     mock_client.get.return_value.status_code = 204
 
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     with patch("time.sleep", return_value=None):  # To speed up the test
@@ -73,12 +68,11 @@ def test_poll_for_tasks_no_task(
     mock_task_handler.assert_not_called()
 
 
-def test_construct_polling_endpoint_with_type(mock_settings, mock_client, mock_task_handler
+def test_construct_polling_endpoint_with_type(
+    mock_settings, mock_client, mock_task_handler
 ):
     # Arrange
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     endpoint = polling_service._construct_polling_endpoint()
@@ -95,9 +89,7 @@ def test_construct_polling_endpoint_without_type(
     mock_settings.COLLECTION_ID = "test_collection"
     mock_settings.TASK_API_TYPE = None
 
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     endpoint = polling_service._construct_polling_endpoint()
@@ -112,7 +104,9 @@ def test_unauthorized_status_code(
 ):
     # Arrange
     mock_client.get.return_value.status_code = 401
-    mock_client.get.return_value.raise_for_status.side_effect = requests.exceptions.RequestException()
+    mock_client.get.return_value.raise_for_status.side_effect = (
+        requests.exceptions.RequestException()
+    )
 
     polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
@@ -129,9 +123,7 @@ def test_other_status_code(
 ):
     # Arrange
     mock_client.get.return_value.status_code = 500
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     polling_service.poll_for_tasks(max_iterations=1)
@@ -146,9 +138,7 @@ def test_network_error(
 ):
     # Arrange
     mock_client.get.side_effect = requests.exceptions.RequestException("Network error")
-    polling_service = PollingService(
-        mock_client, mock_task_handler, mock_settings
-    )
+    polling_service = PollingService(mock_client, mock_task_handler, mock_settings)
 
     # Act
     polling_service.poll_for_tasks(max_iterations=1)

--- a/tests/upstream/test_task_handler.py
+++ b/tests/upstream/test_task_handler.py
@@ -18,17 +18,12 @@ def mock_settings():
 
 
 @pytest.fixture
-def mock_logger():
-    return Mock()
-
-
-@pytest.fixture
 def mock_task_api_client():
     return Mock()
 
 
 def test_handle_task_success(
-    mock_db_manager, mock_settings, mock_logger, mock_task_api_client
+    mock_db_manager, mock_settings, mock_task_api_client
 ):
     # Arrange
     task_data = {"query": "SELECT * FROM table"}
@@ -47,14 +42,13 @@ def test_handle_task_success(
     ) as mock_execute_query:
         # Act
         handle_task(
-            task_data, mock_db_manager, mock_settings, mock_logger, mock_task_api_client
+            task_data, mock_db_manager, mock_settings, mock_task_api_client
         )
 
         # Assert
         mock_execute_query.assert_called_once_with(
             task_data,
             expected_result_modifier,
-            logger=mock_logger,
             db_manager=mock_db_manager,
         )
         mock_task_api_client.send_results.assert_called_once_with(mock_result)

--- a/tests/upstream/test_task_handler.py
+++ b/tests/upstream/test_task_handler.py
@@ -22,9 +22,7 @@ def mock_task_api_client():
     return Mock()
 
 
-def test_handle_task_success(
-    mock_db_manager, mock_settings, mock_task_api_client
-):
+def test_handle_task_success(mock_db_manager, mock_settings, mock_task_api_client):
     # Arrange
     task_data = {"query": "SELECT * FROM table"}
     mock_result = RquestResult(
@@ -41,9 +39,7 @@ def test_handle_task_success(
         return_value=mock_result,
     ) as mock_execute_query:
         # Act
-        handle_task(
-            task_data, mock_db_manager, mock_settings, mock_task_api_client
-        )
+        handle_task(task_data, mock_db_manager, mock_settings, mock_task_api_client)
 
         # Assert
         mock_execute_query.assert_called_once_with(


### PR DESCRIPTION
## Pull Request Contents

| |
|-|
♻️ Refactor

## Description

This PR fixes the logging pattern to a more pythonic approach - due to how the codebase had evolved, it had a mixed methods approach: some dependency injection (explicitly passing the logger to each function), and some module level singleton (importing it).

This wasn't good - and essentially introduced uncertainty into new logging (which pattern to use where), and how settings were then being instantiated in the two entrypoints. This shown in #92 where we had to rerun the settings (by importing `SyncDBManager`) to avoid them being cleared where logging was instantiated later in the app.
(with this change, we are now able to remove the import of `SyncDBManager` that fixed that issue, and make settings instantiation cleaner)

This PR therefore configures the logging once at each entrypoint, and enables each module to `import logger` instead of it being repeatedly injected and further boilerplate code. This is generally accepted as the Python approach to handling logging configuration: https://docs.python.org/3/howto/logging-cookbook.html#using-logging-in-multiple-modules

- Related Issue #92 

## Screenshots, example outputs/behaviour etc.

<!--
ACTION: Add material or delete this section if it's not applicable
-->

## ✅ Added/updated tests?

- [x] This PR contains relevant tests
  - Or doesn't need to per the below explanation

<!--
ACTION: If tests have not been added or updated, explain why here
-->


- [x] I've completed all **actions** and **tasks** detailed in the PR Template
