### PR TITLE
Prevent pytest coverage comment on forked PRs

### DIFF
--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -67,6 +67,8 @@ jobs:
           test ${PIPESTATUS[0]} -eq 0
 
       - name: Pytest coverage comment
+        # Forks do not have the necessary permission to add a comment.
+        if: github.event.pull_request.head.repo.fork == false
         uses: MishaKav/pytest-coverage-comment@81882822c5b22af01f91bd3eacb1cefb6ad73dc2
         with:
           pytest-coverage-path: pytest-coverage.txt


### PR DESCRIPTION
## Pull Request Contents

| |
|-|
🦋 Bug Fix

## Description

Fixes enabling the test check to pass on PRs from forks - the commenting function needs permission, so best to turn it off if head is a fork.

## Related Issues or other material

- [x] This PR relates to one or more issues, detailed below


- Closes #110 


- [x] I've completed all **actions** and **tasks** detailed in the PR Template
