### PR TITLE
Pin workflow tags and permissions

### DIFF
--- a/.github/workflows/check.container-build.yml
+++ b/.github/workflows/check.container-build.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   build:
+    name: Build Container
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/check.container-build.yml
+++ b/.github/workflows/check.container-build.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -46,14 +46,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
         with:
           version: "0.5.16"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -7,6 +7,9 @@ jobs:
   run-tests:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       DATASOURCE_DB_USERNAME: postgres
       DATASOURCE_DB_PASSWORD: postgres

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
@@ -35,7 +35,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: SebRollen/toml-action@v1.2.0
+      - uses: SebRollen/toml-action@b1b3628f55fc3a28208d4203ada8b737e9687876 # v1.2.0
         id: read_version
         with:
           file: pyproject.toml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Docker Metadata action
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
@@ -71,7 +71,7 @@ jobs:
             org.opencontainers.image.description=Hutch Bunny
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/release.versioned.yml
+++ b/.github/workflows/release.versioned.yml
@@ -28,7 +28,7 @@ jobs:
           echo "REPO_OWNER_LOWER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
 
       # read source version
-      - uses: SebRollen/toml-action@v1.2.0
+      - uses: SebRollen/toml-action@b1b3628f55fc3a28208d4203ada8b737e9687876 # v1.2.0
         id: read_version
         with:
           file: pyproject.toml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Parse version from tag
         id: version
-        uses: release-kit/semver@v2
+        uses: release-kit/semver@97491c46500b6e758ced599794164a234b8aa08c # v2.0.7
 
       - name: Fail on Version Mismatch
         if: ${{ steps.read_version.outputs.value != steps.version.outputs.full }}
@@ -45,7 +45,7 @@ jobs:
           exit 1
 
       # check image exists for commit
-      - uses: tyriis/docker-image-tag-exists@v2.1.0
+      - uses: tyriis/docker-image-tag-exists@71a750a41aa78e4efb0842f538140c5df5b8166f # v2.1.0
         with:
           registry: ${{ env.registry }}
           repository: ${{ env.REPO_OWNER_LOWER }}/${{ env.image-name }}
@@ -62,7 +62,7 @@ jobs:
       # We still use the metadata action to help build out our tags from the Workflow Run
       - name: Docker Metadata action
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.image-name }}
           tags: | # new tags only
@@ -71,7 +71,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       # Create Github Release
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref_name }}
@@ -86,7 +86,7 @@ jobs:
 
       # apply the new tags to the existing images
       - name: Push updated image tags
-        uses: akhilerm/tag-push-action@v2.1.0
+        uses: akhilerm/tag-push-action@f35ff2cb99d407368b5c727adbcc14a2ed81d509 # v2.2.0
         with:
           src: ${{ env.registry }}/${{ env.REPO_OWNER_LOWER }}/${{ env.image-name }}:${{ github.sha }}
           dst: |


### PR DESCRIPTION
## Pull Request Contents

<!--
ACTION: Delete any content types that don't apply to your pull request
-->

| |
|-|
🛠️ Repo maintenance

## Description

Pins the Github workflows to commits, rather than version numbers, to reduce risk.
Sets the permissions for workflows without them.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Related Issues or other material

- [x] This PR relates to one or more issues, detailed below

<!--
ACTION: Detail any issues this PR relates to, and then check the box.

NOTE: PRs without issues will not be merged.
-->

<!--
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.

Be careful not to close parent tracking issues that this PR only completes PART of.
-->

- Related Issue #
- Closes #102 


- [x] I've completed all **actions** and **tasks** detailed in the PR Template
