### PR TITLE
Fix settings obfuscation values to 0

### DIFF
--- a/src/hutch_bunny/core/results_modifiers.py
+++ b/src/hutch_bunny/core/results_modifiers.py
@@ -4,23 +4,17 @@ import json
 def results_modifiers(
     low_number_suppression_threshold: int,
     rounding_target: int,
-) -> list:
-    results_modifiers = []
-    if low_number_suppression_threshold:
-        results_modifiers.append(
-            {
-                "id": "Low Number Suppression",
-                "threshold": low_number_suppression_threshold,
-            }
-        )
-    if rounding_target:
-        results_modifiers.append(
-            {
-                "id": "Rounding",
-                "nearest": rounding_target,
-            }
-        )
-    return results_modifiers
+) -> list[dict[str, str | int]]:
+    return [
+        {
+            "id": "Low Number Suppression",
+            "threshold": low_number_suppression_threshold,
+        },
+        {
+            "id": "Rounding",
+            "nearest": rounding_target,
+        },
+    ]
 
 
 def get_results_modifiers_from_str(params: str) -> list[dict]:


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
Fixes the obfuscation to handle being set to 0 if desired.

As `0` in Python is false, this was not being handled by `results_modifiers` properly. But this conditional is not necessary to check. 

## Related Issues or other material
Closes #135 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
