### PR TITLE
Add configuration to wake Azure Serverless DBs

### DIFF
--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -2,6 +2,7 @@ name: Run Tests
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   run-tests:

--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -1,12 +1,11 @@
 name: Run Tests
 
 on:
-  push:
-  workflow_dispatch:
+  pull_request:
 
 jobs:
-  run-tests:
-    name: Run Tests
+  run-tests-postgres:
+    name: Run Tests (Postgres)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,7 +14,7 @@ jobs:
       DATASOURCE_DB_USERNAME: postgres
       DATASOURCE_DB_PASSWORD: postgres
       DATASOURCE_DB_DATABASE: hutch-omop
-      DATASOURCE_DB_SCHEMA: omop
+      DATASOURCE_DB_SCHEMA: public
       DATASOURCE_DB_PORT: 5432
       DATASOURCE_DB_HOST: localhost
       TASK_API_TYPE: a
@@ -39,7 +38,7 @@ jobs:
           - 5432:5432
 
       omop-lite:
-        image: ghcr.io/health-informatics-uon/omop-lite:v0.0.7
+        image: ghcr.io/health-informatics-uon/omop-lite
         env:
           DB_HOST: postgres
           DB_PASSWORD: postgres
@@ -77,3 +76,68 @@ jobs:
         with:
           pytest-coverage-path: pytest-coverage.txt
           junitxml-path: pytest.xml
+  
+  run-tests-sqlserver:
+    name: Run Tests (SQL Server)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      DATASOURCE_DB_USERNAME: sa
+      DATASOURCE_DB_PASSWORD: Password123!
+      DATASOURCE_DB_DATABASE: master
+      DATASOURCE_DB_SCHEMA: omop
+      DATASOURCE_DB_PORT: 1433
+      DATASOURCE_DB_HOST: localhost
+      DATASOURCE_DB_DRIVERNAME: mssql
+      TASK_API_TYPE: a
+      COLLECTION_ID: test_collection
+      TASK_API_BASE_URL: http://localhost:8000
+      TASK_API_USERNAME: test_user
+      TASK_API_PASSWORD: test_password
+
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: Password123!
+          MSSQL_PID: Developer
+        ports:
+          - 1433:1433
+
+      omop-lite:
+        image: ghcr.io/health-informatics-uon/omop-lite
+        env:
+          DB_HOST: sqlserver
+          DB_NAME: master
+          DB_USER: sa
+          DB_PASSWORD: Password123!
+          DB_PORT: 1433
+          DIALECT: mssql
+          SYNTHETIC: true
+          SCHEMA_NAME: omop
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        with:
+          version: "0.5.16"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: uv sync
+        run: uv sync --frozen --dev
+
+      - name: Run tests
+        run: |
+          set -e
+          uv run pytest tests

--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 
 jobs:
-  run-tests-postgres:
-    name: Run Tests (Postgres)
+  run-tests:
+    name: Run Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -14,7 +14,7 @@ jobs:
       DATASOURCE_DB_USERNAME: postgres
       DATASOURCE_DB_PASSWORD: postgres
       DATASOURCE_DB_DATABASE: hutch-omop
-      DATASOURCE_DB_SCHEMA: public
+      DATASOURCE_DB_SCHEMA: omop
       DATASOURCE_DB_PORT: 5432
       DATASOURCE_DB_HOST: localhost
       TASK_API_TYPE: a
@@ -38,7 +38,7 @@ jobs:
           - 5432:5432
 
       omop-lite:
-        image: ghcr.io/health-informatics-uon/omop-lite
+        image: ghcr.io/health-informatics-uon/omop-lite:v0.0.7
         env:
           DB_HOST: postgres
           DB_PASSWORD: postgres
@@ -76,68 +76,3 @@ jobs:
         with:
           pytest-coverage-path: pytest-coverage.txt
           junitxml-path: pytest.xml
-  
-  run-tests-sqlserver:
-    name: Run Tests (SQL Server)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      DATASOURCE_DB_USERNAME: sa
-      DATASOURCE_DB_PASSWORD: Password123!
-      DATASOURCE_DB_DATABASE: master
-      DATASOURCE_DB_SCHEMA: omop
-      DATASOURCE_DB_PORT: 1433
-      DATASOURCE_DB_HOST: localhost
-      DATASOURCE_DB_DRIVERNAME: mssql
-      TASK_API_TYPE: a
-      COLLECTION_ID: test_collection
-      TASK_API_BASE_URL: http://localhost:8000
-      TASK_API_USERNAME: test_user
-      TASK_API_PASSWORD: test_password
-
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-latest
-        env:
-          ACCEPT_EULA: "Y"
-          MSSQL_SA_PASSWORD: Password123!
-          MSSQL_PID: Developer
-        ports:
-          - 1433:1433
-
-      omop-lite:
-        image: ghcr.io/health-informatics-uon/omop-lite
-        env:
-          DB_HOST: sqlserver
-          DB_NAME: master
-          DB_USER: sa
-          DB_PASSWORD: Password123!
-          DB_PORT: 1433
-          DIALECT: mssql
-          SYNTHETIC: true
-          SCHEMA_NAME: omop
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
-        with:
-          version: "0.5.16"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-      
-      - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-        with:
-          python-version-file: ".python-version"
-
-      - name: uv sync
-        run: uv sync --frozen --dev
-
-      - name: Run tests
-        run: |
-          set -e
-          uv run pytest tests

--- a/.github/workflows/check.run-tests.yml
+++ b/.github/workflows/check.run-tests.yml
@@ -1,7 +1,7 @@
 name: Run Tests
 
 on:
-  pull_request:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -5,8 +5,7 @@
 name: Publish a Dev Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   image-name: hutch/bunny

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -5,7 +5,8 @@
 name: Publish a Dev Release
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
 
 env:
   image-name: hutch/bunny

--- a/src/hutch_bunny/core/db.py
+++ b/src/hutch_bunny/core/db.py
@@ -1,6 +1,9 @@
 from hutch_bunny.core.logger import logger
-from hutch_bunny.core.db_manager import SyncDBManager, TrinoDBManager
-
+from hutch_bunny.core.db_manager import (
+    SyncDBManager,
+    TrinoDBManager,
+    WakeAzureDB,
+)
 from hutch_bunny.core.settings import get_settings
 
 settings = get_settings()
@@ -32,6 +35,7 @@ def expand_short_drivers(drivername: str):
     return drivername
 
 
+@WakeAzureDB()
 def get_db_manager() -> SyncDBManager | TrinoDBManager:
     logger.info("Connecting to database...")
 

--- a/src/hutch_bunny/core/db_manager.py
+++ b/src/hutch_bunny/core/db_manager.py
@@ -44,15 +44,16 @@ def WakeAzureDB(
                 try:
                     return func(*args, **kwargs)
                 except OperationalError as e:
-                    if error_code in str(e):
+                    error_msg = str(e)
+                    if error_code in error_msg:
                         if attempt < retries:
                             logger.info(f"{func.__name__} failed with error {error_code}, retrying in {delay} seconds...")
                             time.sleep(delay)
                         else:
                             logger.error(f"{func.__name__} failed with error {error_code} after {retries} retries.")
-                            raise e
+                            raise
                     else:
-                        raise e
+                        raise
         return wrapper
     return decorator
 

--- a/src/hutch_bunny/core/db_manager.py
+++ b/src/hutch_bunny/core/db_manager.py
@@ -20,21 +20,22 @@ def WakeAzureDB(
     delay: int = 30,
     error_code: str = "40613"
 ) -> Any:
-    """Decorator to retry a function on specific failure, conditionally applied.
+    """Decorator to retry a function on specific Azure DB wake-up errors.
 
     Args:
-        retries (int): Number of retries before giving up. Only 1 retry needed
-         to wake an azure db.
-        delay (int): Delay in seconds between retries. 30 seconds gives enough
-         time for the azure db to wake up.
+        retries (int): Number of retries before giving up. Typically 1 retry
+         is sufficient to wake an Azure DB.
+        delay (int): Delay in seconds between retries. 30 seconds is typically
+         enough time for the Azure DB to wake up.
         error_code (str): The error code to check for in the exception. 40613
-         is the error code for an azure db that is asleep.
+         is the error code for an Azure DB that is asleep.
 
     Returns:
-        Callable: The wrapped function with retry logic or the original function.
+        Callable: The wrapped function with retry logic or the original
+         function.
     """
     def decorator(func):
-        if settings.DATASOURCE_DB_DRIVERNAME != "msql":
+        if settings.DATASOURCE_DB_DRIVERNAME != "mssql":
             return func
 
         @wraps(func)
@@ -45,7 +46,7 @@ def WakeAzureDB(
                 except OperationalError as e:
                     if error_code in str(e):
                         if attempt < retries:
-                            logger.warning(f"{func.__name__} failed with error {error_code}, retrying in {delay} seconds...")
+                            logger.info(f"{func.__name__} failed with error {error_code}, retrying in {delay} seconds...")
                             time.sleep(delay)
                         else:
                             logger.error(f"{func.__name__} failed with error {error_code} after {retries} retries.")
@@ -120,6 +121,7 @@ class BaseDBManager:
 
 
 class SyncDBManager(BaseDBManager):
+    @WakeAzureDB()
     def __init__(
         self,
         username: str,

--- a/src/hutch_bunny/core/db_manager.py
+++ b/src/hutch_bunny/core/db_manager.py
@@ -1,11 +1,59 @@
+import time
 from typing import Any, Optional
+from functools import wraps
 
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine import URL as SQLAURL
+from sqlalchemy.exc import OperationalError
 from trino.sqlalchemy import URL as TrinoURL  # TODO: how to do as optional?
 from dotenv import load_dotenv
+from hutch_bunny.core.logger import logger
+from hutch_bunny.core.settings import get_settings
 
+
+settings = get_settings()
 load_dotenv()
+
+
+def WakeAzureDB(
+    retries: int = 1,
+    delay: int = 30,
+    error_code: str = "40613"
+) -> Any:
+    """Decorator to retry a function on specific failure, conditionally applied.
+
+    Args:
+        retries (int): Number of retries before giving up. Only 1 retry needed
+         to wake an azure db.
+        delay (int): Delay in seconds between retries. 30 seconds gives enough
+         time for the azure db to wake up.
+        error_code (str): The error code to check for in the exception. 40613
+         is the error code for an azure db that is asleep.
+
+    Returns:
+        Callable: The wrapped function with retry logic or the original function.
+    """
+    def decorator(func):
+        if settings.DATASOURCE_DB_DRIVERNAME != "msql":
+            return func
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except OperationalError as e:
+                    if error_code in str(e):
+                        if attempt < retries:
+                            logger.warning(f"{func.__name__} failed with error {error_code}, retrying in {delay} seconds...")
+                            time.sleep(delay)
+                        else:
+                            logger.error(f"{func.__name__} failed with error {error_code} after {retries} retries.")
+                            raise e
+                    else:
+                        raise e
+        return wrapper
+    return decorator
 
 
 class BaseDBManager:
@@ -117,20 +165,21 @@ class SyncDBManager(BaseDBManager):
 
         self.inspector = inspect(self.engine)
 
+    @WakeAzureDB()
     def execute_and_fetch(self, stmnt: Any) -> list:
         with self.engine.begin() as conn:
             result = conn.execute(statement=stmnt)
             rows = result.all()
-        # Need to call `dispose` - not automatic
         self.engine.dispose()
         return rows
 
+    @WakeAzureDB()
     def execute(self, stmnt: Any) -> None:
         with self.engine.begin() as conn:
             conn.execute(statement=stmnt)
-        # Need to call `dispose` - not automatic
         self.engine.dispose()
 
+    @WakeAzureDB()
     def list_tables(self) -> list:
         return self.inspector.get_table_names(schema=self.schema)
 

--- a/src/hutch_bunny/core/execute_query.py
+++ b/src/hutch_bunny/core/execute_query.py
@@ -3,8 +3,10 @@ from hutch_bunny.core.logger import logger
 from hutch_bunny.core.solvers import query_solvers
 from hutch_bunny.core.rquest_dto.query import AvailabilityQuery, DistributionQuery
 from hutch_bunny.core.rquest_dto.result import RquestResult
+from hutch_bunny.core.db_manager import WakeAzureDB
 
 
+@WakeAzureDB()
 def execute_query(
     query_dict: Dict,
     results_modifier: list[dict],

--- a/src/hutch_bunny/core/settings.py
+++ b/src/hutch_bunny/core/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     DATASOURCE_DB_CATALOG: str = Field(
         description="The catalog for the datasource database", default="hutch"
     )
+    DATASOURCE_WAKE_DB: bool = Field(
+        description="Flag to allow waking of Azure Serverless DBs", default=False
+    )
 
     def safe_model_dump(self) -> dict:
         """

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock, call
+import time
 from typing import Any, Callable, Optional
 from sqlalchemy.exc import OperationalError
 
@@ -18,14 +19,14 @@ def mock_settings() -> MagicMock:
 
 def simulated_function(should_raise: bool = False, error_code: str = "40613") -> str:
     """Test function that optionally raises an OperationalError.
-
+    
     Args:
         should_raise: Whether to raise an exception
         error_code: Error code to include in the exception message
-
+        
     Returns:
         A success message if no error is raised
-
+        
     Raises:
         OperationalError: If should_raise is True
     """
@@ -35,96 +36,103 @@ def simulated_function(should_raise: bool = False, error_code: str = "40613") ->
 
 
 @pytest.mark.unit
-class TestWakeAzureDB:
-    """Test suite for the WakeAzureDB decorator."""
+def test_no_error(mock_settings: MagicMock) -> None:
+    """Test normal execution without errors."""
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        decorated_func = WakeAzureDB()(simulated_function)
+        result = decorated_func()
+        assert result == "Success"
 
-    def test_no_error(self, mock_settings: MagicMock) -> None:
-        """Test normal execution without errors."""
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            decorated_func = WakeAzureDB()(simulated_function)
+
+@pytest.mark.unit
+def test_with_error_retry_succeeds(mock_settings: MagicMock) -> None:
+    """Test that retry works when the second attempt succeeds."""
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        with patch('time.sleep', return_value=None) as mock_sleep:
+            # Create a function that fails on first call but succeeds on second
+            call_count = 0
+
+            def test_func() -> str:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise OperationalError("Error 40613", "Dummy", "40613")
+                return "Success after retry"
+
+            decorated_func = WakeAzureDB(retries=2, delay=10)(test_func)
             result = decorated_func()
-            assert result == "Success"
+            
+            assert result == "Success after retry"
+            assert call_count == 2
+            mock_sleep.assert_called_once_with(10)
 
-    def test_with_error_retry_succeeds(self, mock_settings: MagicMock) -> None:
-        """Test that retry works when the second attempt succeeds."""
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            with patch('time.sleep', return_value=None) as mock_sleep:
-                # Create a function that fails on first call but succeeds on second
-                call_count = 0
 
-                def test_func() -> str:
-                    nonlocal call_count
-                    call_count += 1
-                    if call_count == 1:
-                        raise OperationalError("Error 40613", "Dummy", "40613")
-                    return "Success after retry"
-
-                decorated_func = WakeAzureDB(retries=2, delay=10)(test_func)
-                result = decorated_func()
-
-                assert result == "Success after retry"
-                assert call_count == 2
-                mock_sleep.assert_called_once_with(10)
-
-    def test_with_error_all_retries_fail(self, mock_settings: MagicMock) -> None:
-        """Test that after all retries fail, the exception is raised."""
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            # Mock sleep to avoid actual delay
-            with patch('time.sleep', return_value=None) as mock_sleep:
-                # Simulate function always failing with relevant error code
-                decorated_func = WakeAzureDB(retries=3, delay=5)(
-                    lambda: simulated_function(True, "40613")
-                )
-
-                with pytest.raises(OperationalError) as exc_info:
-                    decorated_func()
-
-                assert "40613" in str(exc_info.value)
-                assert mock_sleep.call_count == 3
-                assert mock_sleep.call_args_list == [call(5), call(5), call(5)]
-
-    def test_with_different_error(self, mock_settings: MagicMock) -> None:
-        """Test that non-matching error codes don't trigger retries."""
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            with patch('time.sleep', return_value=None) as mock_sleep:
-                # Simulate different error code, expecting no retry
-                decorated_func = WakeAzureDB()(
-                    lambda: simulated_function(True, "12345")
-                )
-
-                with pytest.raises(OperationalError) as exc_info:
-                    decorated_func()
-
-                assert "12345" in str(exc_info.value)
-                mock_sleep.assert_not_called()
-
-    def test_wake_db_disabled(self, mock_settings: MagicMock) -> None:
-        """Test that when DATASOURCE_WAKE_DB is False, no retry logic is applied."""
-        mock_settings.DATASOURCE_WAKE_DB = False
-
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            test_func = MagicMock(side_effect=OperationalError("Error 40613", "Dummy", "40613"))
-            decorated_func = WakeAzureDB()(test_func)
-
-            with pytest.raises(OperationalError):
+@pytest.mark.unit
+def test_with_error_all_retries_fail(mock_settings: MagicMock) -> None:
+    """Test that after all retries fail, the exception is raised."""
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        # Mock sleep to avoid actual delay
+        with patch('time.sleep', return_value=None) as mock_sleep:
+            # Simulate function always failing with relevant error code
+            decorated_func = WakeAzureDB(retries=3, delay=5)(
+                lambda: simulated_function(True, "40613")
+            )
+            
+            with pytest.raises(OperationalError) as exc_info:
                 decorated_func()
+            
+            assert "40613" in str(exc_info.value)
+            assert mock_sleep.call_count == 3
+            assert mock_sleep.call_args_list == [call(5), call(5), call(5)]
 
-            # Function should be called exactly once with no retries
-            test_func.assert_called_once()
 
-    def test_non_mssql_driver(self, mock_settings: MagicMock) -> None:
-        """Test that for non-MSSQL drivers, retry logic is not applied."""
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "postgresql"
-        mock_settings.DATASOURCE_WAKE_DB = True
+@pytest.mark.unit
+def test_with_different_error(mock_settings: MagicMock) -> None:
+    """Test that non-matching error codes don't trigger retries."""
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        with patch('time.sleep', return_value=None) as mock_sleep:
+            # Simulate different error code, expecting no retry
+            decorated_func = WakeAzureDB()(
+                lambda: simulated_function(True, "12345")
+            )
+            
+            with pytest.raises(OperationalError) as exc_info:
+                decorated_func()
+            
+            assert "12345" in str(exc_info.value)
+            mock_sleep.assert_not_called()
 
-        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-            test_func = MagicMock(return_value="Success")
-            decorated_func = WakeAzureDB()(test_func)
 
-            result = decorated_func()
+@pytest.mark.unit
+def test_wake_db_disabled(mock_settings: MagicMock) -> None:
+    """Test that when DATASOURCE_WAKE_DB is False, no retry logic is applied."""
+    mock_settings.DATASOURCE_WAKE_DB = False
+    
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        test_func = MagicMock(side_effect=OperationalError("Error 40613", "Dummy", "40613"))
+        decorated_func = WakeAzureDB()(test_func)
+        
+        with pytest.raises(OperationalError):
+            decorated_func()
+        
+        # Function should be called exactly once with no retries
+        test_func.assert_called_once()
 
-            assert result == "Success"
-            test_func.assert_called_once()
+
+@pytest.mark.unit
+def test_non_mssql_driver(mock_settings: MagicMock) -> None:
+    """Test that for non-MSSQL drivers, retry logic is not applied."""
+    mock_settings.DATASOURCE_DB_DRIVERNAME = "postgresql"
+    mock_settings.DATASOURCE_WAKE_DB = True
+    
+    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+        test_func = MagicMock(return_value="Success")
+        decorated_func = WakeAzureDB()(test_func)
+        
+        result = decorated_func()
+        
+        assert result == "Success"
+        test_func.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -34,6 +34,7 @@ def simulated_function(should_raise: bool = False, error_code: str = "40613") ->
     return "Success"
 
 
+@pytest.mark.unit
 class TestWakeAzureDB:
     """Test suite for the WakeAzureDB decorator."""
 

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -3,40 +3,41 @@ from unittest.mock import patch, MagicMock
 from sqlalchemy.exc import OperationalError
 import time
 
-# Correct import path for decorator
+# Correct import path for the decorator
 from hutch_bunny.core.db_manager import WakeAzureDB
 
 # Mock settings to simulate the environment
 mock_settings = MagicMock()
 mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
 
-# Define the sample function in the test scope
-@WakeAzureDB(retries=2, delay=1, error_code="40613")
-def sample_function():
-    pass
+# Helper function to simulate function calls that may raise an exception
+def simulated_function(should_raise=False, error_code="40613"):
+    if should_raise:
+        raise OperationalError("Dummy", "Dummy", error_code)
+
+# Tests
 
 def test_no_error():
+    # Test normal execution
     with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-        # Test normal execution
-        sample_function()
+        decorated_func = WakeAzureDB()(simulated_function)
+        decorated_func()
 
 def test_with_error():
     with patch('hutch_bunny.core.db_manager.settings', mock_settings):
         # Mock sleep to avoid actual delay
         with patch('time.sleep', return_value=None):
             # Simulate function failure with relevant error code
-            with patch('__main__.sample_function', side_effect=OperationalError("Dummy", "Dummy", "40613")) as mock_func:
-                with pytest.raises(OperationalError):
-                    sample_function()
-                assert mock_func.call_count == 3  # Initial call + 2 retries
+            decorated_func = WakeAzureDB()(lambda: simulated_function(True, "40613"))
+            with pytest.raises(OperationalError):
+                decorated_func()
 
 def test_with_different_error():
     with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-        # Test with a different error code, should not retry
-        with patch('__main__.sample_function', side_effect=OperationalError("Dummy", "Dummy", "DifferentError")) as mock_func:
-            with pytest.raises(OperationalError):
-                sample_function()
-            assert mock_func.call_count == 1  # No retries
+        # Simulate different error code, expecting no retry
+        decorated_func = WakeAzureDB()(lambda: simulated_function(True, "DifferentError"))
+        with pytest.raises(OperationalError):
+            decorated_func()
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -4,40 +4,97 @@ from sqlalchemy.exc import OperationalError
 from hutch_bunny.core.db_manager import WakeAzureDB
 
 
+# Mock functions at the top of the file
 @WakeAzureDB(retries=2, delay=1, error_code="40613")
-def mock_function():
-    """A mock function to test the WakeAzureDB decorator."""
-    raise OperationalError("OperationalError with code 40613", None, None)
+def mock_function_with_matching_error():
+    """A mock function that raises an error with the matching error code."""
+    raise OperationalError("(40613) Database is currently unavailable", None, None)
 
 
 @WakeAzureDB(retries=2, delay=1, error_code="40613")
-def mock_function_no_error():
+def mock_function_with_non_matching_error():
+    """A mock function that raises an error with a non-matching error code."""
+    raise OperationalError("(40615) Some other error", None, None)
+
+
+@WakeAzureDB(retries=2, delay=1, error_code="40613")
+def mock_function_success():
     """A mock function that succeeds without errors."""
     return "Success"
 
 
 @pytest.mark.unit
-def test_wake_azure_db_retries():
-    """Test that the decorator retries the specified number of times."""
-    with patch("time.sleep", return_value=None) as mock_sleep:
+class TestWakeAzureDB:
+    """Tests for the WakeAzureDB decorator."""
+
+    def setup_method(self):
+        """Set up common test components."""
+        self.sleep_patcher = patch("time.sleep", return_value=None)
+        self.mock_sleep = self.sleep_patcher.start()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        self.sleep_patcher.stop()
+
+    def test_matching_error_retries(self):
+        """Test that the decorator retries when error code matches."""
+        # Reset call count (in case tests run in a different order)
+        self.mock_sleep.reset_mock()
+
+        # Should retry twice and then raise
+        with pytest.raises(OperationalError) as excinfo:
+            mock_function_with_matching_error()
+
+        # Verify error message contains the expected error code
+        assert "40613" in str(excinfo.value)
+
+        # Verify sleep was called twice (for retries)
+        assert self.mock_sleep.call_count == 2
+        assert self.mock_sleep.call_args_list == [call(1), call(1)]
+
+    def test_non_matching_error_no_retry(self):
+        """Test that the decorator doesn't retry for non-matching error codes."""
+        # Reset call count
+        self.mock_sleep.reset_mock()
+
+        # Should raise immediately, no retries
+        with pytest.raises(OperationalError) as excinfo:
+            mock_function_with_non_matching_error()
+
+        # Verify error message doesn't contain matching code
+        assert "40613" not in str(excinfo.value)
+
+        # Verify sleep was not called (no retries)
+        assert self.mock_sleep.call_count == 0
+
+    def test_successful_execution(self):
+        """Test that the decorator allows successful execution without retries."""
+        # Reset call count
+        self.mock_sleep.reset_mock()
+
+        # Should succeed without any retries
+        result = mock_function_success()
+
+        # Verify the return value
+        assert result == "Success"
+
+        # Verify sleep was not called
+        assert self.mock_sleep.call_count == 0
+
+    @patch("some_module.settings.DATASOURCE_DB_DRIVERNAME", "postgres")
+    def test_non_mssql_driver(self):
+        """Test that the decorator doesn't add retry logic for non-MSSQL drivers."""
+        # Define a test function with a non-MSSQL driver
+        @WakeAzureDB(retries=2, delay=1, error_code="40613")
+        def postgres_function():
+            raise OperationalError("(40613) Error", None, None)
+
+        # Reset call count
+        self.mock_sleep.reset_mock()
+
+        # Should raise immediately, no retries
         with pytest.raises(OperationalError):
-            mock_function()
-        assert mock_sleep.call_count == 2  # Retries twice
+            postgres_function()
 
-
-@pytest.mark.unit
-def test_wake_azure_db_success():
-    """Test that the decorator allows successful execution."""
-    result = mock_function_no_error()
-    assert result == "Success"
-
-
-@pytest.mark.unit
-def test_wake_azure_db_non_matching_error():
-    """Test that the decorator does not retry for non-matching error codes."""
-    @WakeAzureDB(retries=2, delay=1, error_code="40613")
-    def mock_function_different_error():
-        raise OperationalError("OperationalError with different code", None, None)
-
-    with pytest.raises(OperationalError):
-        mock_function_different_error()
+        # Verify sleep was not called (no retries)
+        assert self.mock_sleep.call_count == 0

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -3,14 +3,14 @@ from unittest.mock import patch, MagicMock
 from sqlalchemy.exc import OperationalError
 import time
 
-# Correct import path for the decorator
+# Correct import path for decorator
 from hutch_bunny.core.db_manager import WakeAzureDB
 
 # Mock settings to simulate the environment
 mock_settings = MagicMock()
 mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
 
-# Sample function to decorate
+# Define the sample function in the test scope
 @WakeAzureDB(retries=2, delay=1, error_code="40613")
 def sample_function():
     pass
@@ -25,8 +25,7 @@ def test_with_error():
         # Mock sleep to avoid actual delay
         with patch('time.sleep', return_value=None):
             # Simulate function failure with relevant error code
-            error = OperationalError("Dummy", "Dummy", "40613")
-            with patch('hutch_bunny.core.db_manager.sample_function', side_effect=error) as mock_func:
+            with patch('__main__.sample_function', side_effect=OperationalError("Dummy", "Dummy", "40613")) as mock_func:
                 with pytest.raises(OperationalError):
                     sample_function()
                 assert mock_func.call_count == 3  # Initial call + 2 retries
@@ -34,8 +33,7 @@ def test_with_error():
 def test_with_different_error():
     with patch('hutch_bunny.core.db_manager.settings', mock_settings):
         # Test with a different error code, should not retry
-        error = OperationalError("Dummy", "Dummy", "DifferentError")
-        with patch('hutch_bunny.core.db_manager.sample_function', side_effect=error) as mock_func:
+        with patch('__main__.sample_function', side_effect=OperationalError("Dummy", "Dummy", "DifferentError")) as mock_func:
             with pytest.raises(OperationalError):
                 sample_function()
             assert mock_func.call_count == 1  # No retries

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -1,156 +1,57 @@
-import pytest
-from unittest.mock import patch, MagicMock, Mock
+import time
+from unittest.mock import patch, Mock
 from sqlalchemy.exc import OperationalError
-from hutch_bunny.core.db_manager import WakeAzureDB
-from hutch_bunny.core.upstream.task_api_client import TaskApiClient
+from decorators import WakeAzureDB  # Adjust import based on actual file structure
 
+# Setting up mock components
+class MockSettings:
+    DATASOURCE_DB_DRIVERNAME = "mssql"
 
 @pytest.fixture
 def mock_settings():
-    mock_settings = Mock()
-    mock_settings.COLLECTION_ID = "test_collection"
-    mock_settings.TASK_API_TYPE = "test_type"
-    mock_settings.INITIAL_BACKOFF = 1
-    mock_settings.MAX_BACKOFF = 8
-    mock_settings.POLLING_INTERVAL = 0.1
-    return mock_settings
-
-
-@pytest.fixture
-def mock_client():
-    return Mock(spec=TaskApiClient)
-
+    return MockSettings()
 
 @pytest.fixture
 def mock_logger():
-    with patch("hutch_bunny.core.upstream.polling_service.logger") as mock_logger:
+    with patch("decorators.logger") as mock_logger:
         yield mock_logger
 
+# A sample function to apply the decorator
+@WakeAzureDB(retries=2, delay=1, error_code="40613")
+def sample_function():
+    raise OperationalError("An error occurred", params=None, orig=None)
 
-@pytest.fixture
-def mock_task_handler():
-    return Mock()
+def test_retry_decorator_success(mock_settings, mock_logger):
+    # Patch the settings globally
+    with patch("decorators.settings", mock_settings):
+        # Patch time.sleep to avoid actual sleeping during tests
+        with patch("time.sleep", return_value=None):
+            with patch("decorators.sample_function", return_value="Success") as mock_func:
+                # Modify sample_function to first raise error, then succeed
+                mock_func.side_effect = [
+                    OperationalError("An error 40613 occurred", None, None),
+                    OperationalError("An error 40613 occurred", None, None),
+                    "Success"
+                ]
+                # Call the decorated function
+                result = sample_function()
 
+                # Assert the result
+                assert result == "Success"
+                # Assert logger calls
+                assert mock_logger.info.call_count == 2
+                assert mock_logger.error.call_count == 0
 
-# Create a proper OperationalError for SQLAlchemy
-def create_operational_error(message):
-    # The SQLAlchemy OperationalError needs statement, params, and orig
-    statement = "SELECT 1"
-    params = {}
-    orig = Exception(message)
-    return OperationalError(statement, params, orig)
-
-
-def test_decorator_passes_through_for_non_mssql():
-    """Test that the decorator passes through when not using MSSQL."""
-    # Use patch with the actual path to settings, not the fixture
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings:
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "postgresql"
-
-        # Create a simple function to decorate
-        @WakeAzureDB()
-        def test_func():
-            return "success"
-
-        # The function should be returned as-is without wrapping
-        assert test_func() == "success"
-
-
-def test_successful_execution_no_retry():
-    """Test successful execution without any need for retry."""
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings:
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
-
-        mock_func = MagicMock(return_value="success")
-        decorated_func = WakeAzureDB()(mock_func)
-
-        result = decorated_func("arg1", kwarg1="kwarg1")
-
-        assert result == "success"
-        mock_func.assert_called_once_with("arg1", kwarg1="kwarg1")
-
-
-def test_retry_on_specific_error():
-    """Test that the function retries on the specific Azure DB error."""
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings, \
-         patch('hutch_bunny.core.db_manager.time.sleep') as mock_sleep, \
-         patch('hutch_bunny.core.db_manager.logger') as mock_logger:
-
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
-
-        # Create proper error with all required parameters
-        error = create_operational_error("Error code 40613: The database is currently busy.")
-        
-        # Mock function that fails once with the specific error, then succeeds
-        mock_func = MagicMock(side_effect=[error, "success"])
-
-        decorated_func = WakeAzureDB(retries=2, delay=5, error_code="40613")(mock_func)
-
-        result = decorated_func()
-
-        assert result == "success"
-        assert mock_func.call_count == 2
-        mock_sleep.assert_called_once_with(5)
-        mock_logger.info.assert_called_once()
-
-
-def test_raises_after_max_retries():
-    """Test that the function raises after maximum retries are exhausted."""
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings, \
-         patch('hutch_bunny.core.db_manager.time.sleep') as mock_sleep, \
-         patch('hutch_bunny.core.db_manager.logger') as mock_logger:
-
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
-
-        # Create an error with the specific error code
-        error = create_operational_error("Error code 40613: The database is currently busy.")
-
-        # Mock function that always fails with the specific error
-        mock_func = MagicMock(side_effect=error)
-
-        decorated_func = WakeAzureDB(retries=2, delay=5, error_code="40613")(mock_func)
-
-        # The function should raise after retries are exhausted
-        with pytest.raises(OperationalError) as excinfo:
-            decorated_func()
-
-        assert "40613" in str(excinfo.value)
-        assert mock_func.call_count == 3  # Initial call + 2 retries
-        assert mock_sleep.call_count == 2
-        assert mock_logger.info.call_count == 2
-        mock_logger.error.assert_called_once()
-
-
-def test_different_error_passes_through():
-    """Test that different errors pass through without retry."""
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings:
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
-
-        # Create an error with a different error code
-        error = create_operational_error("Error code 12345: Some other error.")
-
-        # Mock function that fails with a different error
-        mock_func = MagicMock(side_effect=error)
-
-        decorated_func = WakeAzureDB()(mock_func)
-
-        # The function should immediately raise with the different error
-        with pytest.raises(OperationalError) as excinfo:
-            decorated_func()
-
-        assert "12345" in str(excinfo.value)
-        mock_func.assert_called_once()
-
-
-def test_preserves_function_metadata():
-    """Test that the decorator preserves the original function's metadata."""
-    with patch("hutch_bunny.core.db_manager.settings") as mock_settings:
-        mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
-        
-        @WakeAzureDB()
-        def test_func():
-            """Test function docstring."""
-            pass
-        
-        assert test_func.__name__ == "test_func"
-        assert test_func.__doc__ == "Test function docstring."
+def test_retry_decorator_fail(mock_settings, mock_logger):
+    # Patch the settings globally
+    with patch("decorators.settings", mock_settings):
+        # Patch time.sleep to avoid actual sleeping during tests
+        with patch("time.sleep", return_value=None):
+            with patch("decorators.sample_function", side_effect=OperationalError("An error 40613 occurred", None, None)):
+                # Check if the retry mechanism works and eventually raises an error
+                with pytest.raises(OperationalError):
+                    sample_function()
+                
+                # Assert logger calls
+                assert mock_logger.info.call_count == 2
+                assert mock_logger.error.call_count == 1

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -1,43 +1,130 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
+from typing import Any, Callable, Optional
 from sqlalchemy.exc import OperationalError
-import time
 
-# Correct import path for the decorator
 from hutch_bunny.core.db_manager import WakeAzureDB
 
-# Mock settings to simulate the environment
-mock_settings = MagicMock()
-mock_settings.DATASOURCE_DB_DRIVERNAME = "mssql"
 
-# Helper function to simulate function calls that may raise an exception
-def simulated_function(should_raise=False, error_code="40613"):
+# Setup test fixtures
+@pytest.fixture
+def mock_settings() -> MagicMock:
+    """Create a mock settings object for testing."""
+    settings = MagicMock()
+    settings.DATASOURCE_DB_DRIVERNAME = "mssql"
+    settings.DATASOURCE_WAKE_DB = True
+    return settings
+
+
+def simulated_function(should_raise: bool = False, error_code: str = "40613") -> str:
+    """Test function that optionally raises an OperationalError.
+
+    Args:
+        should_raise: Whether to raise an exception
+        error_code: Error code to include in the exception message
+
+    Returns:
+        A success message if no error is raised
+
+    Raises:
+        OperationalError: If should_raise is True
+    """
     if should_raise:
-        raise OperationalError("Dummy", "Dummy", error_code)
+        raise OperationalError(f"Error {error_code}", "Dummy", error_code)
+    return "Success"
 
-# Tests
 
-def test_no_error():
-    # Test normal execution
-    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-        decorated_func = WakeAzureDB()(simulated_function)
-        decorated_func()
+class TestWakeAzureDB:
+    """Test suite for the WakeAzureDB decorator."""
 
-def test_with_error():
-    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-        # Mock sleep to avoid actual delay
-        with patch('time.sleep', return_value=None):
-            # Simulate function failure with relevant error code
-            decorated_func = WakeAzureDB()(lambda: simulated_function(True, "40613"))
+    def test_no_error(self, mock_settings: MagicMock) -> None:
+        """Test normal execution without errors."""
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            decorated_func = WakeAzureDB()(simulated_function)
+            result = decorated_func()
+            assert result == "Success"
+
+    def test_with_error_retry_succeeds(self, mock_settings: MagicMock) -> None:
+        """Test that retry works when the second attempt succeeds."""
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            with patch('time.sleep', return_value=None) as mock_sleep:
+                # Create a function that fails on first call but succeeds on second
+                call_count = 0
+
+                def test_func() -> str:
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count == 1:
+                        raise OperationalError("Error 40613", "Dummy", "40613")
+                    return "Success after retry"
+
+                decorated_func = WakeAzureDB(retries=2, delay=10)(test_func)
+                result = decorated_func()
+
+                assert result == "Success after retry"
+                assert call_count == 2
+                mock_sleep.assert_called_once_with(10)
+
+    def test_with_error_all_retries_fail(self, mock_settings: MagicMock) -> None:
+        """Test that after all retries fail, the exception is raised."""
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            # Mock sleep to avoid actual delay
+            with patch('time.sleep', return_value=None) as mock_sleep:
+                # Simulate function always failing with relevant error code
+                decorated_func = WakeAzureDB(retries=3, delay=5)(
+                    lambda: simulated_function(True, "40613")
+                )
+
+                with pytest.raises(OperationalError) as exc_info:
+                    decorated_func()
+
+                assert "40613" in str(exc_info.value)
+                assert mock_sleep.call_count == 3
+                assert mock_sleep.call_args_list == [call(5), call(5), call(5)]
+
+    def test_with_different_error(self, mock_settings: MagicMock) -> None:
+        """Test that non-matching error codes don't trigger retries."""
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            with patch('time.sleep', return_value=None) as mock_sleep:
+                # Simulate different error code, expecting no retry
+                decorated_func = WakeAzureDB()(
+                    lambda: simulated_function(True, "12345")
+                )
+
+                with pytest.raises(OperationalError) as exc_info:
+                    decorated_func()
+
+                assert "12345" in str(exc_info.value)
+                mock_sleep.assert_not_called()
+
+    def test_wake_db_disabled(self, mock_settings: MagicMock) -> None:
+        """Test that when DATASOURCE_WAKE_DB is False, no retry logic is applied."""
+        mock_settings.DATASOURCE_WAKE_DB = False
+
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            test_func = MagicMock(side_effect=OperationalError("Error 40613", "Dummy", "40613"))
+            decorated_func = WakeAzureDB()(test_func)
+
             with pytest.raises(OperationalError):
                 decorated_func()
 
-def test_with_different_error():
-    with patch('hutch_bunny.core.db_manager.settings', mock_settings):
-        # Simulate different error code, expecting no retry
-        decorated_func = WakeAzureDB()(lambda: simulated_function(True, "DifferentError"))
-        with pytest.raises(OperationalError):
-            decorated_func()
+            # Function should be called exactly once with no retries
+            test_func.assert_called_once()
+
+    def test_non_mssql_driver(self, mock_settings: MagicMock) -> None:
+        """Test that for non-MSSQL drivers, retry logic is not applied."""
+        mock_settings.DATASOURCE_DB_DRIVERNAME = "postgresql"
+        mock_settings.DATASOURCE_WAKE_DB = True
+
+        with patch('hutch_bunny.core.db_manager.settings', mock_settings):
+            test_func = MagicMock(return_value="Success")
+            decorated_func = WakeAzureDB()(test_func)
+
+            result = decorated_func()
+
+            assert result == "Success"
+            test_func.assert_called_once()
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/test_wake_azure_db.py
+++ b/tests/unit/test_wake_azure_db.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import patch
+from sqlalchemy.exc import OperationalError
+from hutch_bunny.core.db_manager import WakeAzureDB
+
+
+@WakeAzureDB(retries=2, delay=1, error_code="40613")
+def mock_function():
+    """A mock function to test the WakeAzureDB decorator."""
+    raise OperationalError("OperationalError with code 40613", None, None)
+
+
+@WakeAzureDB(retries=2, delay=1, error_code="40613")
+def mock_function_no_error():
+    """A mock function that succeeds without errors."""
+    return "Success"
+
+
+@pytest.mark.unit
+def test_wake_azure_db_retries():
+    """Test that the decorator retries the specified number of times."""
+    with patch("time.sleep", return_value=None) as mock_sleep:
+        with pytest.raises(OperationalError):
+            mock_function()
+        assert mock_sleep.call_count == 2  # Retries twice
+
+
+@pytest.mark.unit
+def test_wake_azure_db_success():
+    """Test that the decorator allows successful execution."""
+    result = mock_function_no_error()
+    assert result == "Success"
+
+
+@pytest.mark.unit
+def test_wake_azure_db_non_matching_error():
+    """Test that the decorator does not retry for non-matching error codes."""
+    @WakeAzureDB(retries=2, delay=1, error_code="40613")
+    def mock_function_different_error():
+        raise OperationalError("OperationalError with different code", None, None)
+
+    with pytest.raises(OperationalError):
+        mock_function_different_error()


### PR DESCRIPTION
✨ Feature

## PR Description

Our idea is to create a decorator that wraps any function that connects or sends a query to the DB.
Adding extra config in settings, the queries should only ever run on the set 'paused' error from sql alchemy (40613) AND when the data source is mssql

## Related Issues or other material
Related https://github.com/Health-Informatics-UoN/hutch-bunny/issues/146

## Screenshots, example outputs/behaviour etc.
![image](https://github.com/user-attachments/assets/25e6d379-98ad-416d-90c8-3500761b44f0)


## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

Added unit tests for the following scenarios:

test_no_error: Verifies that when the decorated function executes without raising any exceptions, the decorator simply passes through the result without attempting any retries.

test_with_error_retry_succeeds: Tests that when the function fails on the first attempt with the expected Azure DB error code (40613), the decorator waits the specified delay time and then retries. The test confirms the function succeeds on the second attempt and returns the correct result.

test_with_error_all_retries_fail: Checks that when the function consistently fails with the Azure error code even after multiple retry attempts (3 in this case), the decorator eventually gives up and re-raises the original exception. It also verifies that the sleep function is called the correct number of times with the right delay parameter.

test_with_different_error: Ensures that when the function raises an operational error with a different error code than the one we're looking for, the decorator doesn't attempt any retries and immediately raises the exception.

test_wake_db_disabled: Tests the new DATASOURCE_WAKE_DB setting. When this setting is set to False, the decorator should skip all retry logic and simply call the original function directly, even if it raises the Azure DB wake-up error.

test_non_mssql_driver: Verifies that when the database driver isn't MSSQL (which is what Azure DB uses), the retry logic isn't applied regardless of other settings.
