### PR TITLE
Add availability end to end tests

### DIFF
--- a/tests/end_to_end/test_cli_availability.py
+++ b/tests/end_to_end/test_cli_availability.py
@@ -70,6 +70,26 @@ test_cases = [
         '[{"id": "Rounding", "nearest": 0}]',
         55,
     ),
+    (
+        "tests/queries/availability/measurement.json",
+        '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
+        12,
+    ),
+    (
+        "tests/queries/availability/multiple_in_group_exclusion_time.json",
+        '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
+        13,
+    ),
+    (
+        "tests/queries/availability/basic_ethnicity_or.json",
+        '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
+        41,
+    ),
+    (
+        "tests/queries/availability/basic_race_or.json",
+        '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
+        95,
+    ),
 ]
 
 

--- a/tests/end_to_end/test_cli_availability.py
+++ b/tests/end_to_end/test_cli_availability.py
@@ -90,6 +90,11 @@ test_cases = [
         '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
         95,
     ),
+    (
+        "tests/queries/availability/secondary_modifiers.json",
+        '[{"id": "Low Number Suppression", "threshold": 0}, {"id": "Rounding", "nearest": 0}]',
+        13,
+    ),
 ]
 
 

--- a/tests/end_to_end/test_cli_distribution.py
+++ b/tests/end_to_end/test_cli_distribution.py
@@ -20,45 +20,57 @@ test_cases = [
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers="[]",
-        expected_count=4,
+        expected_count=7,
         expected_values={
             "8507": 40,  # MALE
             "8532": 60,  # FEMALE
             "38003564": 40,  # Not Hispanic
             "38003563": 60,  # Hispanic
+            "35626061": 10,
+            "4323688": 20,
+            "4266009": 10,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 0}]',
-        expected_count=4,
+        expected_count=7,
         expected_values={
             "8507": 44,
             "8532": 55,
             "38003564": 41,
             "38003563": 58,
+            "35626061": 11,
+            "4323688": 24,
+            "4266009": 12,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 100}]',
-        expected_count=4,
+        expected_count=7,
         expected_values={
             "8507": 0,
             "8532": 100,
             "38003564": 0,
             "38003563": 100,
+            "35626061": 0,
+            "4323688": 0,
+            "4266009": 0,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 10}, {"id": "Low Number Suppression", "threshold": 10}]',
-        expected_count=4,
+        expected_count=7,
         expected_values={
             "8507": 40,
             "8532": 60,
             "38003564": 40,
             "38003563": 60,
+            "35626061": 10,
+            "4323688": 20,
+            "4266009": 10,
         },
     ),
     DistributionTestCase(
@@ -157,9 +169,9 @@ def test_cli_distribution(test_case: DistributionTestCase) -> None:
 
             # Validate count is an integer
             count_str = fields[2]  # COUNT column as string
-            assert count_str.isdigit(), (
-                f"Expected an integer count, but got: {count_str}"
-            )
+            assert (
+                count_str.isdigit()
+            ), f"Expected an integer count, but got: {count_str}"
             count = int(count_str)  # Convert to int after validation
             assert count == test_case.expected_values[omop_code]
 

--- a/tests/end_to_end/test_cli_distribution.py
+++ b/tests/end_to_end/test_cli_distribution.py
@@ -20,7 +20,7 @@ test_cases = [
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers="[]",
-        expected_count=7,
+        expected_count=8,
         expected_values={
             "8507": 40,  # MALE
             "8532": 60,  # FEMALE
@@ -29,12 +29,13 @@ test_cases = [
             "35626061": 10,
             "4323688": 20,
             "4266009": 10,
+            "21490742": 10,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 0}]',
-        expected_count=7,
+        expected_count=8,
         expected_values={
             "8507": 44,
             "8532": 55,
@@ -43,12 +44,13 @@ test_cases = [
             "35626061": 11,
             "4323688": 24,
             "4266009": 12,
+            "21490742": 12,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 100}]',
-        expected_count=7,
+        expected_count=8,
         expected_values={
             "8507": 0,
             "8532": 100,
@@ -57,12 +59,13 @@ test_cases = [
             "35626061": 0,
             "4323688": 0,
             "4266009": 0,
+            "21490742": 0,
         },
     ),
     DistributionTestCase(
         json_file_path="tests/queries/distribution/distribution.json",
         modifiers='[{"id": "Rounding", "nearest": 10}, {"id": "Low Number Suppression", "threshold": 10}]',
-        expected_count=7,
+        expected_count=8,
         expected_values={
             "8507": 40,
             "8532": 60,
@@ -71,6 +74,7 @@ test_cases = [
             "35626061": 10,
             "4323688": 20,
             "4266009": 10,
+            "21490742": 10,
         },
     ),
     DistributionTestCase(

--- a/tests/queries/availability/basic_ethnicity_or.json
+++ b/tests/queries/availability/basic_ethnicity_or.json
@@ -1,0 +1,31 @@
+{
+  "task_id" : "job-2025-02-14-09:00:54-RQ-6bdd4145-d484-47c5-a699-4d776fb9851a",
+  "project" : "project_id",
+  "owner" : "user1",
+  "cohort" : {
+    "groups" : [ {
+      "rules" : [ {
+        "varname" : "OMOP",
+        "varcat" : "Person",
+        "type" : "TEXT",
+        "oper" : "=",
+        "value" : "38003564"
+      } ],
+      "rules_oper" : "AND"
+    }, {
+      "rules" : [ {
+        "varname" : "OMOP",
+        "varcat" : "Person",
+        "type" : "TEXT",
+        "oper" : "!=",
+        "value" : "38003563"
+      } ],
+      "rules_oper" : "AND"
+    } ],
+    "groups_oper" : "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version" : "v2",
+  "char_salt" : "salt",
+  "uuid" : "unique_id"
+}

--- a/tests/queries/availability/basic_race_or.json
+++ b/tests/queries/availability/basic_race_or.json
@@ -1,0 +1,31 @@
+{
+  "task_id" : "job-2025-02-14-09:00:54-RQ-6bdd4145-d484-47c5-a699-4d776fb9851a",
+  "project" : "project_id",
+  "owner" : "user1",
+  "cohort" : {
+    "groups" : [ {
+      "rules" : [ {
+        "varname" : "OMOP",
+        "varcat" : "Person",
+        "type" : "TEXT",
+        "oper" : "=",
+        "value" : "38003575"
+      } ],
+      "rules_oper" : "AND"
+    }, {
+      "rules" : [ {
+        "varname" : "OMOP",
+        "varcat" : "Person",
+        "type" : "TEXT",
+        "oper" : "!=",
+        "value" : "38003579"
+      } ],
+      "rules_oper" : "AND"
+    } ],
+    "groups_oper" : "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version" : "v2",
+  "char_salt" : "salt",
+  "uuid" : "unique_id"
+}

--- a/tests/queries/availability/measurement.json
+++ b/tests/queries/availability/measurement.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "job-2023-01-13-14: 20: 38-project",
+  "project": "project_id",
+  "owner": "user1",
+  "cohort": {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP=21490742",
+            "varcat": "Measurement",
+            "type": "NUM",
+            "oper": "=",
+            "value": "1.0|3.0"
+          }
+        ],
+        "rules_oper": "AND"
+      }
+    ],
+    "groups_oper": "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version": "v2",
+  "char_salt": "salt",
+  "uuid": "unique_id"
+}

--- a/tests/queries/availability/multiple_in_group_exclusion_time.json
+++ b/tests/queries/availability/multiple_in_group_exclusion_time.json
@@ -1,0 +1,47 @@
+{
+  "task_id" : "job-2025-02-14-09:03:27-RQ-87808b58-b878-4b59-839f-3537727c64a6",
+  "project" : "project_id",
+  "owner" : "user1",
+  "cohort" : {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Condition",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "4323688",
+            "time": "1|:TIME:M"
+          },
+          {
+            "varname": "OMOP",
+            "varcat": "Condition",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "4323688",
+            "time": "|1:TIME:M"
+          }
+        ],
+        "rules_oper": "OR"
+      },
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Condition",
+            "type": "TEXT",
+            "oper": "!=",
+            "value": "35626061"
+          }
+        ],
+        "rules_oper": "OR"
+      }
+    ],
+    "groups_oper": "AND"
+  },
+  "collection": "collection_id",
+  "protocol_version" : "v2",
+  "char_salt" : "salt",
+  "uuid" : "unique_id"
+}

--- a/tests/queries/availability/secondary_modifiers.json
+++ b/tests/queries/availability/secondary_modifiers.json
@@ -1,0 +1,27 @@
+{
+  "task_id" : "job-2025-02-14-09:03:27-RQ-87808b58-b878-4b59-839f-3537727c64a6",
+  "project" : "project_id",
+  "owner" : "user1",
+  "cohort" : {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Condition",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "4323688",
+            "secondary_modifier" : [ "32020" ]
+          }
+        ],
+        "rules_oper": "OR"
+      }
+    ],
+    "groups_oper": "AND"
+  },
+  "collection": "collection_id",
+  "protocol_version" : "v2",
+  "char_salt" : "salt",
+  "uuid" : "unique_id"
+}


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description
Add further end to end tests focussing on availability queries and previously untested code. Adds tests for:
- Ethnicity 
- Race
- Measurement
- Exclusion queries
- Time
- Secondary modifiers

The test data also was updated to include more useful data, therefore distribution tests have been updated to account for this. See https://github.com/Health-Informatics-UoN/omop-lite/pull/21

I do expect the test pattern to be improved to enable these tests to be reused for the daemon in an upcoming PR.

## Related Issues or other material
Closes #154 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
