### PR TITLE
Refactor end to end test pattern

### DIFF
--- a/tests/end_to_end/test_cases/availability_test_cases.py
+++ b/tests/end_to_end/test_cases/availability_test_cases.py
@@ -5,6 +5,19 @@ import json
 
 @dataclass
 class AvailabilityTestCase:
+    """Test case for availability queries.
+
+    This class represents a test case for availability queries, with support for
+    rounding and low number suppression modifiers.
+    The test case can be converted to the JSON format required by the CLI using get_modifiers_json().
+
+    Attributes:
+        json_file_path: Path to the JSON query file
+        expected_count: Expected count of results
+        rounding: Optional rounding parameter (nearest value)
+        low_number_suppression: Optional threshold for low number suppression
+    """
+
     json_file_path: str
     expected_count: int
     rounding: Optional[int] = None

--- a/tests/end_to_end/test_cases/availability_test_cases.py
+++ b/tests/end_to_end/test_cases/availability_test_cases.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from typing import Optional
+import json
+
+
+@dataclass
+class AvailabilityTestCase:
+    json_file_path: str
+    expected_count: int
+    rounding: Optional[int] = None
+    low_number_suppression: Optional[int] = None
+
+    def get_modifiers_json(self) -> str:
+        """Convert the modifiers to a JSON string format."""
+        modifiers_list = []
+        if self.rounding is not None:
+            modifiers_list.append({"id": "Rounding", "nearest": self.rounding})
+        if self.low_number_suppression is not None:
+            modifiers_list.append(
+                {
+                    "id": "Low Number Suppression",
+                    "threshold": self.low_number_suppression,
+                }
+            )
+        return json.dumps(modifiers_list)
+
+
+test_cases = [
+    # Basic availability test - assert default rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        expected_count=40,
+    ),
+    # Basic availability test - assert rounding to 0.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        rounding=0,
+        expected_count=44,
+    ),
+    # Basic availability test - assert overriden rounding and low number suppression.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        rounding=0,
+        low_number_suppression=0,
+        expected_count=44,
+    ),
+    # Basic availability test - assert overriden rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        low_number_suppression=30,
+        expected_count=40,
+    ),
+    # Basic availability test - assert low number suppression on threshold.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        low_number_suppression=40,
+        expected_count=40,
+    ),
+    # Basic availability test - assert rounding and low number suppression.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        rounding=10,
+        low_number_suppression=20,
+        expected_count=40,
+    ),
+    # Basic availability test - assert rounding to 100.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        rounding=100,
+        expected_count=0,
+    ),
+    # Basic availability test - assert rounding to 10.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/availability.json",
+        rounding=10,
+        expected_count=40,
+    ),
+    # Basic gender test - assert gender OR filtering with default rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/basic_gender_or.json",
+        expected_count=100,
+    ),
+    # Basic gender test - assert gender OR filtering with rounding to 0.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/basic_gender_or.json",
+        rounding=0,
+        expected_count=99,
+    ),
+    # Multiple in group test - assert multiple in group AND filtering with default rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_and.json",
+        expected_count=0,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with default rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or.json",
+        expected_count=60,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with rounding to 0.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or.json",
+        rounding=0,
+        expected_count=55,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with age 1.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or_with_age1.json",
+        expected_count=60,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with age 1 and rounding to 0.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or_with_age1.json",
+        rounding=0,
+        expected_count=55,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with age 2.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or_with_age2.json",
+        expected_count=60,
+    ),
+    # Mutiple in group test - assert multiple in group OR filtering with age 2 and rounding to 0.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_or_with_age2.json",
+        rounding=0,
+        expected_count=55,
+    ),
+    # Basic measurement test - assert measurement with default rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/measurement.json",
+        rounding=0,
+        low_number_suppression=10,
+        expected_count=12,
+    ),
+    # Multiple in group, exclusion criteria, and time test.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/multiple_in_group_exclusion_time.json",
+        rounding=0,
+        low_number_suppression=10,
+        expected_count=13,
+    ),
+    # Basic ethnicity test - assert ethnicity OR filtering with override rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/basic_ethnicity_or.json",
+        rounding=0,
+        low_number_suppression=0,
+        expected_count=41,
+    ),
+    # Basic race test - assert race OR filtering with override rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/basic_race_or.json",
+        rounding=0,
+        low_number_suppression=0,
+        expected_count=95,
+    ),
+    # Secondary modifiers test - assert secondary modifiers with override rounding.
+    AvailabilityTestCase(
+        json_file_path="tests/queries/availability/secondary_modifiers.json",
+        rounding=0,
+        low_number_suppression=0,
+        expected_count=13,
+    ),
+]

--- a/tests/end_to_end/test_cli_availability.py
+++ b/tests/end_to_end/test_cli_availability.py
@@ -3,145 +3,10 @@ import pytest
 import os
 import json
 import sys
-from dataclasses import dataclass
-from typing import Optional
-
-
-@dataclass
-class AvailabilityTestCase:
-    json_file_path: str
-    expected_count: int
-    rounding: Optional[int] = None
-    low_number_suppression: Optional[int] = None
-
-    def get_modifiers_json(self) -> str:
-        """Convert the modifiers to a JSON string format."""
-        modifiers_list = []
-        if self.rounding is not None:
-            modifiers_list.append({"id": "Rounding", "nearest": self.rounding})
-        if self.low_number_suppression is not None:
-            modifiers_list.append(
-                {
-                    "id": "Low Number Suppression",
-                    "threshold": self.low_number_suppression,
-                }
-            )
-        return json.dumps(modifiers_list)
-
-
-test_cases = [
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        expected_count=40,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        rounding=0,
-        expected_count=44,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=44,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        low_number_suppression=30,
-        expected_count=40,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        low_number_suppression=40,
-        expected_count=40,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        rounding=10,
-        low_number_suppression=20,
-        expected_count=40,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        rounding=100,
-        expected_count=0,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/availability.json",
-        rounding=10,
-        expected_count=40,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/basic_gender_or.json",
-        expected_count=100,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/basic_gender_or.json",
-        rounding=0,
-        expected_count=99,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_and.json",
-        expected_count=0,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or.json",
-        expected_count=60,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or.json",
-        rounding=0,
-        expected_count=55,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or_with_age1.json",
-        expected_count=60,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or_with_age1.json",
-        rounding=0,
-        expected_count=55,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or_with_age2.json",
-        expected_count=60,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_or_with_age2.json",
-        rounding=0,
-        expected_count=55,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/measurement.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=12,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/multiple_in_group_exclusion_time.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=13,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/basic_ethnicity_or.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=41,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/basic_race_or.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=95,
-    ),
-    AvailabilityTestCase(
-        json_file_path="tests/queries/availability/secondary_modifiers.json",
-        rounding=0,
-        low_number_suppression=0,
-        expected_count=13,
-    ),
-]
+from tests.end_to_end.test_cases.availability_test_cases import (
+    test_cases,
+    AvailabilityTestCase,
+)
 
 
 @pytest.mark.end_to_end
@@ -154,7 +19,7 @@ def test_cli_availability(test_case: AvailabilityTestCase) -> None:
     and assert the output is as expected.
 
     Args:
-        test_case (AvailabilityTestCase): The test case containing the JSON file path, modifiers, and expected count.
+        test_case: The test case containing the JSON file path, modifiers, and expected count.
 
     Returns:
         None


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
♻️ Refactor

## PR Description
Refactors the end to end availability tests pattern, by creating a dataclass to store the test cases.

This is in preparation for #101, to enable these tests to be easily reused across both entry points. This way - each entry point is responsible for parsing the test case into its required format. 

It also probably makes them reusable across integration tests also.

Also adds documentation to describe each test case. 

## Related Issues or other material
Related #101 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
