### PR TITLE
Feature/cache distribution query results

### DIFF
--- a/src/hutch_bunny/core/services/cache_service.py
+++ b/src/hutch_bunny/core/services/cache_service.py
@@ -1,0 +1,101 @@
+import os
+import json
+import hashlib
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+from hutch_bunny.core.logger import logger
+from hutch_bunny.core.settings import Settings
+
+
+class DistributionCacheService: 
+    """Service for caching distribution query results."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings 
+        self.cache_dir = Path(settings.CACHE_DIR) 
+        self.enabled = settings.CACHE_ENABLED 
+        self.ttl_hours = settings.CACHE_TTL_HOURS 
+
+        if self.enabled: 
+            self._ensure_cache_dir() 
+    
+    def _ensure_cache_dir(self) -> None: 
+        """Create cache directory if it doesn't exist."""
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _generate_cache_key(self, query_dict: dict, modifiers: list) -> str: 
+        """Generate a unique cache key for the query."""
+        # Create a deterministic hash from a query and modifiers 
+        cache_data = {
+            "query": query_dict, 
+            "modifiers": modifiers 
+        }
+        cache_str = json.dumps(cache_data, sort_keys=True)
+        return hashlib.sha256(cache_str.encode()).hexdigest()
+    
+    def _get_cache_path(self, cache_key: str) -> Path: 
+        """Get the file path for a cache key."""
+        return self.cache_dir / f"{cache_key}.json"
+
+    def _is_cache_valid(self, cache_path: Path) -> bool: 
+        """Check if cache file exists and is still valid."""
+        if not cache_path.exists():
+            return False
+        
+        if self.ttl_hours == 0:  # No expiration
+            return True
+        
+        # Check cache time-to-live TTL
+        file_time = datetime.fromtimestamp(cache_path.stat().st_mtime)
+        expiry_time = file_time + timedelta(hours=self.ttl_hours)
+        return datetime.now() < expiry_time
+    
+    def get(self, query_dict: dict[str, str], modifiers: list) -> Optional[dict]: 
+        """Retrieve cached result if available and valid."""
+        if not self.enabled: 
+            return None 
+        
+        cache_key = self._generate_cache_key(query_dict, modifiers)
+        cache_path = self._get_cache_path(cache_key)
+
+        if self._is_cache_valid(cache_path):
+            try:
+                with open(cache_path, 'r') as f:
+                    cached_data = json.load(f)
+                logger.info(f"Cache hit for distribution query: {cache_key}")
+                return cached_data
+            except Exception as e:
+                logger.error(f"Error reading cache: {e}")
+                return None
+        
+        return None 
+    
+    def set(self, query_dict: dict[str, str], modifiers: list, result: dict) -> None: 
+        """Store result in cache."""
+        if not self.enabled:
+            return
+        
+        cache_key = self._generate_cache_key(query_dict, modifiers)
+        cache_path = self._get_cache_path(cache_key)
+
+        try:
+            with open(cache_path, 'w') as f:
+                json.dump(result, f)
+            logger.info(f"Cached distribution query result: {cache_key}")
+        except Exception as e:
+            logger.error(f"Error writing cache: {e}")
+
+    def clear(self) -> None:
+        """Clear all cached results."""
+        if not self.enabled:
+            return
+        
+        for cache_file in self.cache_dir.glob("*.json"):
+            try:
+                cache_file.unlink()
+            except Exception as e:
+                logger.error(f"Error deleting cache file {cache_file}: {e}")
+        
+        logger.info("Cache cleared")
+

--- a/src/hutch_bunny/core/settings.py
+++ b/src/hutch_bunny/core/settings.py
@@ -11,6 +11,16 @@ class Settings(BaseSettings):  # type: ignore
     """
     Settings for the application
     """
+    CACHE_ENABLED: bool = Field(
+        description="Enable caching of distribution query results",
+        default=False,
+        alias="BUNNY_CACHE_ENABLED"
+    )
+    CACHE_DIR: str = Field(
+        description="Directory to store cached distribution results",
+        default="/tmp/bunny_cache",  # need to change to within the repo 
+        alias="BUNNY_CACHE_DIR"
+    )
     CACHE_TTL_HOURS: int = Field(
         description="Cache validity (time-to-live) period in hours (0 = never expires)",
         default=24,
@@ -18,7 +28,7 @@ class Settings(BaseSettings):  # type: ignore
     )
     CACHE_REFRESH_INTERVAL_HOURS: int = Field(
         description="How often to proactively refresh cache in hours (0 = no auto-refresh)",
-        default=24,  # maybe need ot change 
+        default=24,  # need to change I think  
         alias="BUNNY_CACHE_REFRESH_INTERVAL_HOURS"  
     )
     CACHE_REFRESH_ON_STARTUP: bool = Field(

--- a/src/hutch_bunny/core/settings.py
+++ b/src/hutch_bunny/core/settings.py
@@ -11,7 +11,21 @@ class Settings(BaseSettings):  # type: ignore
     """
     Settings for the application
     """
-
+    CACHE_TTL_HOURS: int = Field(
+        description="Cache validity (time-to-live) period in hours (0 = never expires)",
+        default=24,
+        alias="BUNNY_CACHE_TTL_HOURS"
+    )
+    CACHE_REFRESH_INTERVAL_HOURS: int = Field(
+        description="How often to proactively refresh cache in hours (0 = no auto-refresh)",
+        default=24,  # maybe need ot change 
+        alias="BUNNY_CACHE_REFRESH_INTERVAL_HOURS"  
+    )
+    CACHE_REFRESH_ON_STARTUP: bool = Field(
+        description="Refresh cache when daemon starts",
+        default=True,
+        alias="BUNNY_CACHE_REFRESH_ON_STARTUP"
+    )
     DATASOURCE_USE_TRINO: bool = Field(
         description="Whether to use Trino as the datasource", default=False
     )


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature
⚡️ Optimization

## PR Description
Create a cache to store the distribution query results for optimisation purposes. I have done this by: 
- Creating a `DistributionCacheService` in `core/services` which is responsible for instantiating and validating the existence of the cache. It also gets and sets the results of individual distributions queries. 
- The mechanism for storing cached results involves hashing the query dictionary and the modifiers list into a unique key which serves as the filename of json cache file.  

## Related Issues or other material
Related #189
Closes #189

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [] This PR contains relevant tests
