### PR TITLE
feat: Support for OMOP Death Table

### DIFF
--- a/src/hutch_bunny/core/db/entities.py
+++ b/src/hutch_bunny/core/db/entities.py
@@ -247,6 +247,17 @@ class DrugExposure(Base):
     dose_unit_source_value = Column(String(50), nullable=True)
 
 
+class Death(Base):
+    __tablename__ = "death"
+    person_id = Column(Integer, ForeignKey("person.person_id"), primary_key=True)
+    death_date = Column(Date, nullable=False)
+    death_datetime = Column(DateTime, nullable=True)
+    death_type_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
+    cause_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
+    cause_source_value = Column(String(50), nullable=True)
+    cause_source_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
+
+
 class Specimen(Base):
     __tablename__ = "specimen"
     specimen_id = Column(Integer, primary_key=True)

--- a/src/hutch_bunny/core/omop.py
+++ b/src/hutch_bunny/core/omop.py
@@ -13,3 +13,4 @@ class Varcat(StrEnum):
     PROCEDURE = "Procedure"
     SPECIMEN = "Specimen"
     LOCATION = "Location"
+    DEATH = "Death"

--- a/src/hutch_bunny/core/settings.py
+++ b/src/hutch_bunny/core/settings.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
         description="Enable support for querying OMOP location table records",
         default=False,
     )
+    OMOP_DEATH_ENABLED: bool = Field(
+        description="Enable support for querying OMOP death table records",
+        default=False,
+    )
 
     LOGGER_NAME: str = "hutch"
     LOGGER_LEVEL: str = Field(

--- a/src/hutch_bunny/core/solvers/availability_solver.py
+++ b/src/hutch_bunny/core/solvers/availability_solver.py
@@ -181,6 +181,7 @@ class AvailabilitySolver():
             self.db_client,
             include_specimen=settings.OMOP_SPECIMEN_ENABLED,
             include_location=settings.OMOP_LOCATION_ENABLED,
+            include_death=settings.OMOP_DEATH_ENABLED,
             varcat=rule.varcat,
         )
 

--- a/src/hutch_bunny/core/solvers/distribution_solver.py
+++ b/src/hutch_bunny/core/solvers/distribution_solver.py
@@ -10,11 +10,13 @@ from hutch_bunny.core.db import BaseDBClient
 from hutch_bunny.core.db.entities import (
     Concept,
     ConditionOccurrence,
+    Death,
     Measurement,
     Observation,
     Person,
     DrugExposure,
-    ProcedureOccurrence, Specimen,
+    ProcedureOccurrence,
+    Specimen,
 )
 from tenacity import (
     retry,
@@ -32,11 +34,13 @@ from hutch_bunny.core.settings import Settings
 # Type alias for tables that have person_id
 PersonTable = Union[
     ConditionOccurrence,
+    Death,
     Measurement,
     Observation,
     Person,
     DrugExposure,
     ProcedureOccurrence,
+    Specimen,
 ]
 
 settings = Settings()
@@ -104,6 +108,7 @@ class CodeDistributionQuerySolver:
         "Observation": Observation,
         "Procedure": ProcedureOccurrence,
         "Specimen": Specimen,
+        "Death": Death,
     }
     domain_concept_id_map = {
         "Condition": ConditionOccurrence.condition_concept_id,
@@ -115,6 +120,7 @@ class CodeDistributionQuerySolver:
         "Observation": Observation.observation_concept_id,
         "Procedure": ProcedureOccurrence.procedure_concept_id,
         "Specimen": Specimen.specimen_concept_id,
+        "Death": Death.cause_concept_id,
     }
 
     # this one is unique for this resolver
@@ -182,6 +188,9 @@ class CodeDistributionQuerySolver:
             for domain_id in self.allowed_domains_map:
 
                 if not settings.OMOP_SPECIMEN_ENABLED and domain_id == "Specimen":
+                    continue
+
+                if not settings.OMOP_DEATH_ENABLED and domain_id == "Death":
                     continue
 
                 logger.debug(domain_id)

--- a/src/hutch_bunny/core/solvers/rule_query_builders.py
+++ b/src/hutch_bunny/core/solvers/rule_query_builders.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 from hutch_bunny.core.db import BaseDBClient
 from hutch_bunny.core.db.entities import (
     ConditionOccurrence,
+    Death,
     Location,
     Measurement,
     Observation,
@@ -111,10 +112,14 @@ class OMOPRuleQueryBuilder:
     guarding against vocabulary drift between the querying party and the local
     CDM. Specimen is unioned in too whenever `include_specimen` is enabled.
 
-    Location is the one exception: it has no equivalent per-person clinical
-    event table to union with the others, so a `varcat` of `Location` bypasses
-    that union entirely and targets the `location` table alone via a join
-    through `person.location_id`.
+    Location and Death are exceptions to that union. Location has no
+    equivalent per-person clinical event table to union with the others, so
+    a `varcat` of `Location` bypasses that union entirely and targets the
+    `location` table alone via a join through `person.location_id`. Death is
+    excluded for a different reason: a concept recorded as `cause_concept_id`
+    describes what a person died of, which is not the same clinical fact as
+    that concept appearing in their clinical history, so a `varcat` of
+    `Death` also bypasses the union and targets the `death` table alone.
     """
 
     def __init__(
@@ -123,11 +128,13 @@ class OMOPRuleQueryBuilder:
         varcat: Varcat | None = None,
         include_specimen: bool = False,
         include_location: bool = False,
+        include_death: bool = False,
     ):
         self.db_client = db_client
         self.include_specimen = include_specimen
         self.include_location = include_location
         self.is_location_rule = varcat == Varcat.LOCATION
+        self.is_death_rule = varcat == Varcat.DEATH
 
         self.condition_query: Select[Tuple[int]] = select(ConditionOccurrence.person_id)
         self.drug_query: Select[Tuple[int]] = select(DrugExposure.person_id)
@@ -143,6 +150,9 @@ class OMOPRuleQueryBuilder:
             )
             if self.is_location_rule and include_location
             else None
+        )
+        self.death_query: Select[Tuple[int]] | None = (
+            select(Death.person_id) if self.is_death_rule and include_death else None
         )
 
     def add_concept_constraint(self, concept_id: int) -> "OMOPRuleQueryBuilder":
@@ -176,6 +186,10 @@ class OMOPRuleQueryBuilder:
         if self.specimen_query is not None:
             self.specimen_query = self.specimen_query.where(
                 Specimen.specimen_concept_id == concept_id
+            )
+        if self.death_query is not None:
+            self.death_query = self.death_query.where(
+                Death.cause_concept_id == concept_id
             )
         return self
 
@@ -258,6 +272,14 @@ class OMOPRuleQueryBuilder:
                 self.specimen_query,
                 Specimen.person_id,
                 Specimen.specimen_date,
+                comparator,
+                age_value,
+            )
+        if self.death_query is not None:
+            self.death_query = self._apply_age_constraint_to_table(
+                self.death_query,
+                Death.person_id,
+                Death.death_date,
                 comparator,
                 age_value,
             )
@@ -379,6 +401,10 @@ class OMOPRuleQueryBuilder:
                 self.specimen_query = self.specimen_query.where(
                     Specimen.specimen_date >= relative_date
                 )
+            if self.death_query is not None:
+                self.death_query = self.death_query.where(
+                    Death.death_date >= relative_date
+                )
         else:
             self.measurement_query = self.measurement_query.where(
                 Measurement.measurement_date <= relative_date
@@ -398,6 +424,10 @@ class OMOPRuleQueryBuilder:
             if self.specimen_query is not None:
                 self.specimen_query = self.specimen_query.where(
                     Specimen.specimen_date <= relative_date
+                )
+            if self.death_query is not None:
+                self.death_query = self.death_query.where(
+                    Death.death_date <= relative_date
                 )
         return self
 
@@ -523,6 +553,11 @@ class OMOPRuleQueryBuilder:
         (or a stub that contributes no matches, if `OMOP_LOCATION_ENABLED` is
         off) rather than unioning with the clinical tables above.
 
+        Similarly, a `Death` rule returns just the death query (or a stub, if
+        `OMOP_DEATH_ENABLED` is off). Cause-of-death is a distinct clinical
+        fact from having a concept recorded in the person's clinical history,
+        so it is deliberately not unioned with the other tables.
+
         Returns:
             CompoundSelect query that unions results from all tables.
 
@@ -534,6 +569,12 @@ class OMOPRuleQueryBuilder:
             if self.location_query is not None:
                 return union(self.location_query)
             # OMOP_LOCATION_ENABLED is off - contribute no matches.
+            return union(select(Person.person_id).where(text("1=0")))
+
+        if self.is_death_rule:
+            if self.death_query is not None:
+                return union(self.death_query)
+            # OMOP_DEATH_ENABLED is off - contribute no matches.
             return union(select(Person.person_id).where(text("1=0")))
 
         queries: list[Select[Tuple[int]]] = [

--- a/tests/end_to_end/test_cli_death.py
+++ b/tests/end_to_end/test_cli_death.py
@@ -1,0 +1,98 @@
+import subprocess
+import pytest
+import os
+import json
+import sys
+from typing import Any
+
+DEATH_ANY_QUERY_FILE = "tests/queries/availability/death_any.json"
+DEATH_ALIVE_QUERY_FILE = "tests/queries/availability/death_alive.json"
+
+
+def _run_cli(
+    json_file_path: str, *, death_enabled: bool, output_file_path: str
+) -> dict[Any, Any]:
+    """Run the CLI against a query file with OMOP_DEATH_ENABLED forced on or off."""
+    env = os.environ.copy()
+    env["OMOP_DEATH_ENABLED"] = "true" if death_enabled else "false"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "hutch_bunny.cli",
+        "--body",
+        json_file_path,
+        "--modifiers",
+        json.dumps(
+            [
+                {"id": "Rounding", "nearest": 0},
+                {"id": "Low Number Suppression", "threshold": 0},
+            ]
+        ),
+        "--output",
+        output_file_path,
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert result.returncode == 0, f"CLI failed with error: {result.stderr}"
+    assert os.path.exists(output_file_path), "Output file was not created."
+
+    with open(output_file_path, "r") as f:
+        output_data: dict[Any, Any] = json.load(f)
+
+    os.remove(output_file_path)
+    return output_data
+
+
+@pytest.mark.end_to_end
+def test_cli_death_disabled_any_returns_no_matches() -> None:
+    """With OMOP_DEATH_ENABLED off, a Death '=' rule contributes zero matches,
+    regardless of what the death table contains."""
+    output_file_path = "tests/queries/availability/output_death_disabled_any.json"
+    output_data = _run_cli(
+        DEATH_ANY_QUERY_FILE, death_enabled=False, output_file_path=output_file_path
+    )
+
+    assert output_data["status"] == "ok"
+    assert output_data["queryResult"]["count"] == 0
+
+
+@pytest.mark.end_to_end
+def test_cli_death_disabled_alive_matches_everyone() -> None:
+    """With OMOP_DEATH_ENABLED off, a Death '!=' rule is a negation of an empty
+    match set, so it matches every person rather than zero."""
+    output_file_path = "tests/queries/availability/output_death_disabled_alive.json"
+    output_data = _run_cli(
+        DEATH_ALIVE_QUERY_FILE, death_enabled=False, output_file_path=output_file_path
+    )
+
+    assert output_data["status"] == "ok"
+    assert output_data["queryResult"]["count"] == 1130
+
+
+@pytest.mark.end_to_end
+@pytest.mark.parametrize(
+    "json_file_path, expected_count",
+    [
+        # 142 persons have a death record in the omop-lite >=0.7.0 synthetic data.
+        (DEATH_ANY_QUERY_FILE, 142),
+        # The remaining 988 of 1130 persons have no death record.
+        (DEATH_ALIVE_QUERY_FILE, 988),
+        # No death row in the synthetic data has this cause_concept_id.
+        ("tests/queries/availability/death_specific_concept.json", 0),
+        # Death AND Condition 260139 narrows the 142 deceased down to 54.
+        ("tests/queries/availability/death_with_condition.json", 54),
+    ],
+)
+def test_cli_death_enabled(json_file_path: str, expected_count: int) -> None:
+    """With OMOP_DEATH_ENABLED on, Death rules query the death table directly."""
+    output_file_path = "tests/queries/availability/output_death_enabled.json"
+    output_data = _run_cli(
+        json_file_path, death_enabled=True, output_file_path=output_file_path
+    )
+
+    assert output_data["status"] == "ok"
+    assert output_data["protocolVersion"] == "v2"
+    assert output_data["queryResult"]["count"] == expected_count
+    assert output_data["queryResult"]["datasetCount"] == 0
+    assert output_data["queryResult"]["files"] == []

--- a/tests/queries/availability/death_alive.json
+++ b/tests/queries/availability/death_alive.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "job-death-alive",
+  "project": "project_id",
+  "owner": "user1",
+  "cohort": {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Death",
+            "type": "TEXT",
+            "oper": "!=",
+            "value": ""
+          }
+        ],
+        "rules_oper": "AND"
+      }
+    ],
+    "groups_oper": "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version": "v2",
+  "char_salt": "salt",
+  "uuid": "unique_id"
+}

--- a/tests/queries/availability/death_any.json
+++ b/tests/queries/availability/death_any.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "job-death-any",
+  "project": "project_id",
+  "owner": "user1",
+  "cohort": {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Death",
+            "type": "TEXT",
+            "oper": "=",
+            "value": ""
+          }
+        ],
+        "rules_oper": "AND"
+      }
+    ],
+    "groups_oper": "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version": "v2",
+  "char_salt": "salt",
+  "uuid": "unique_id"
+}

--- a/tests/queries/availability/death_specific_concept.json
+++ b/tests/queries/availability/death_specific_concept.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "job-death-specific-concept",
+  "project": "project_id",
+  "owner": "user1",
+  "cohort": {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Death",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "4329847"
+          }
+        ],
+        "rules_oper": "AND"
+      }
+    ],
+    "groups_oper": "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version": "v2",
+  "char_salt": "salt",
+  "uuid": "unique_id"
+}

--- a/tests/queries/availability/death_with_condition.json
+++ b/tests/queries/availability/death_with_condition.json
@@ -1,0 +1,33 @@
+{
+  "task_id": "job-death-with-condition",
+  "project": "project_id",
+  "owner": "user1",
+  "cohort": {
+    "groups": [
+      {
+        "rules": [
+          {
+            "varname": "OMOP",
+            "varcat": "Death",
+            "type": "TEXT",
+            "oper": "=",
+            "value": ""
+          },
+          {
+            "varname": "OMOP",
+            "varcat": "Condition",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "260139"
+          }
+        ],
+        "rules_oper": "AND"
+      }
+    ],
+    "groups_oper": "OR"
+  },
+  "collection": "collection_id",
+  "protocol_version": "v2",
+  "char_salt": "salt",
+  "uuid": "unique_id"
+}

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -164,3 +164,17 @@ def test_location_support_disabled_by_default() -> None:
 
         assert settings.OMOP_LOCATION_ENABLED is False
 
+
+@pytest.mark.unit
+def test_death_support_disabled_by_default() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        settings = Settings(
+            DATASOURCE_DB_PASSWORD="db_secret",
+            DATASOURCE_DB_HOST="localhost",
+            DATASOURCE_DB_PORT=5432,
+            DATASOURCE_DB_SCHEMA="public",
+            DATASOURCE_DB_DATABASE="test_db",
+        )
+
+        assert settings.OMOP_DEATH_ENABLED is False
+

--- a/tests/unit/solvers/test_rule_query_builders.py
+++ b/tests/unit/solvers/test_rule_query_builders.py
@@ -7,27 +7,23 @@ from sqlalchemy.sql import CompoundSelect
 from sqlalchemy.sql.elements import literal_column
 from sqlalchemy.dialects import postgresql
 
-from hutch_bunny.core.solvers.rule_query_builders import (
-    SQLDialectHandler,
-    OMOPRuleQueryBuilder,
-    PersonConstraintBuilder,
-)
+from hutch_bunny.core.solvers.rule_query_builders import SQLDialectHandler, OMOPRuleQueryBuilder, PersonConstraintBuilder
 
 
 class TestSQLDialectHandler:
+
     def test_get_year_difference_unsupported_dialect(self) -> None:
         """Test that an unsupported dialect raises NotImplementedError."""
         metadata = MetaData()
         test_table = Table(
-            "test",
-            metadata,
+            "test", metadata,
             Column("start_date", Date),
             Column("birth_date", Date),
         )
 
         # Mock engine with unsupported dialect name
         engine = Mock()
-        engine.dialect.name = "mysql"
+        engine.dialect.name = "mysql"  
 
         start_date = test_table.c.start_date
         birth_date = test_table.c.birth_date
@@ -42,8 +38,7 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test",
-            metadata,
+            "test", metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -51,11 +46,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(
-            engine, start_date, year_of_birth
-        )
+        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
 
-        assert str(result) == str(func.date_part("year", start_date) - year_of_birth)
+        assert str(result) == str(
+            func.date_part("year", start_date) - year_of_birth
+        )
 
     def test_get_year_difference_duckdb(self) -> None:
         """Test DuckDB dialect returns correct function."""
@@ -64,8 +59,7 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test",
-            metadata,
+            "test", metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -73,11 +67,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(
-            engine, start_date, year_of_birth
-        )
+        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
 
-        assert str(result) == str(func.date_part("year", start_date) - year_of_birth)
+        assert str(result) == str(
+            func.date_part("year", start_date) - year_of_birth
+        )
 
     def test_get_year_difference_mssql(self) -> None:
         """Test MSSQL dialect returns correct function."""
@@ -86,8 +80,7 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test",
-            metadata,
+            "test", metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -95,9 +88,7 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(
-            engine, start_date, year_of_birth
-        )
+        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
 
         assert str(result) == str(
             func.DATEPART(text("year"), start_date) - year_of_birth
@@ -110,8 +101,7 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test",
-            metadata,
+            "test", metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -119,11 +109,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(
-            engine, start_date, year_of_birth
-        )
+        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
 
-        assert str(result) == str(func.YEAR(start_date) - year_of_birth)
+        assert str(result) == str(
+            func.YEAR(start_date) - year_of_birth)
+
 
     def test_get_year_difference_with_actual_column_elements(self) -> None:
         """Test with actual SQLAlchemy column elements."""
@@ -133,7 +123,7 @@ class TestSQLDialectHandler:
         Base = declarative_base()
 
         class TestTable(Base):
-            __tablename__ = "test"
+            __tablename__ = 'test'
             id = Column(Integer, primary_key=True)
             start_date = Column(Date)
             birth_date = Column(Date)
@@ -141,20 +131,22 @@ class TestSQLDialectHandler:
         # Test with PostgreSQL
         pg_engine = create_engine("postgresql+psycopg://user:pass@localhost/db")
         result = SQLDialectHandler.get_year_difference(
-            pg_engine, TestTable.start_date, TestTable.birth_date
+            pg_engine,
+            TestTable.start_date,
+            TestTable.birth_date
         )
 
         # Verify it produces valid SQL when compiled
-        compiled = str(
-            result.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
+        compiled = str(result.compile(
+            dialect=postgresql.dialect(), 
+            compile_kwargs={"literal_binds": True}
+        ))
         assert "date_part" in compiled
         assert "year" in compiled
 
 
-class TestOMOPRuleQueryBuilder:
+class TestOMOPRuleQueryBuilder():
+    
     def test_add_concept_constraint(self) -> None:
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -162,16 +154,12 @@ class TestOMOPRuleQueryBuilder:
         concept_id = 111
         builder.add_concept_constraint(concept_id)
 
-        compiled = builder.condition_query.compile(
-            compile_kwargs={"literal_binds": True}
-        )
+        compiled = builder.condition_query.compile(compile_kwargs={"literal_binds": True})
         sql_str = str(compiled)
 
         assert "WHERE condition_occurrence.condition_concept_id = 111" in sql_str
 
-    @patch(
-        "hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference"
-    )
+    @patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference")
     def test_add_age_constraint(self, mock_get_year_diff: Mock) -> None:
         mock_get_year_diff.return_value = literal_column("25")
 
@@ -180,14 +168,12 @@ class TestOMOPRuleQueryBuilder:
 
         builder.add_age_constraint("20", "")  # age > 20
 
-        compiled = builder.condition_query.compile(
-            compile_kwargs={"literal_binds": True}
-        )
+        compiled = builder.condition_query.compile(compile_kwargs={"literal_binds": True})
         sql_str = str(compiled)
 
         assert "25 >= 20" in sql_str
 
-    def test_add_temporal_constraint_only_left_constraint_present(self) -> None:
+    def test_add_temporal_constraint_only_left_constraint_present(self) -> None: 
         greater_than_value = "1"
         less_than_value = ""
 
@@ -197,19 +183,15 @@ class TestOMOPRuleQueryBuilder:
         relative_date = fixed_now + relativedelta(months=time_to_use)
 
         expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
-        expected_sql_fragment = (
-            f"condition_occurrence.condition_start_date <= '{expected_date_str}'"
-        )
+        expected_sql_fragment = f"condition_occurrence.condition_start_date <= '{expected_date_str}'"
 
-        with patch(
-            "hutch_bunny.core.solvers.rule_query_builders.datetime"
-        ) as mock_datetime:
+        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime: 
             mock_datetime.now.return_value = fixed_now
 
             mock_db_manager = Mock()
             builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-            builder.add_temporal_constraint(greater_than_value, less_than_value)
+            builder.add_temporal_constraint(greater_than_value, less_than_value )
 
             compiled = builder.condition_query.compile(
                 compile_kwargs={"literal_binds": True}
@@ -217,8 +199,8 @@ class TestOMOPRuleQueryBuilder:
             sql_str = str(compiled)
 
             assert expected_sql_fragment in sql_str
-
-    def test_add_temporal_constraint_only_right_constraint_present(self) -> None:
+    
+    def test_add_temporal_constraint_only_right_constraint_present(self) -> None: 
         greater_than_value = ""
         less_than_value = "1"
 
@@ -228,13 +210,9 @@ class TestOMOPRuleQueryBuilder:
         relative_date = fixed_now + relativedelta(months=time_to_use)
 
         expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
-        expected_sql_fragment = (
-            f"condition_occurrence.condition_start_date >= '{expected_date_str}'"
-        )
+        expected_sql_fragment = f"condition_occurrence.condition_start_date >= '{expected_date_str}'"
 
-        with patch(
-            "hutch_bunny.core.solvers.rule_query_builders.datetime"
-        ) as mock_datetime:
+        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime: 
             mock_datetime.now.return_value = fixed_now
 
             mock_db_manager = Mock()
@@ -249,59 +227,55 @@ class TestOMOPRuleQueryBuilder:
 
             assert expected_sql_fragment in sql_str
 
-    def test_add_temporal_constraint_no_input(self) -> None:
+    def test_add_temporal_constraint_no_input(self) -> None: 
         greater_than_value = ""
         less_than_value = ""
 
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError): 
             builder.add_temporal_constraint(greater_than_value, less_than_value)
-
-    def test_add_temporal_constraint_both_inputs(self) -> None:
+    
+    def test_add_temporal_constraint_both_inputs(self) -> None: 
         greater_than_value = "1"
         less_than_value = "2"
 
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError): 
             builder.add_temporal_constraint(greater_than_value, less_than_value)
 
-    def test_add_numeric_range_with_no_input(self) -> None:
+    def test_add_numeric_range_with_no_input(self) -> None: 
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_numeric_range()
 
-        measurement_sql = str(
-            builder.measurement_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-        observation_sql = str(
-            builder.observation_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-        condition_sql = str(
-            builder.condition_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-        drug_sql = str(
-            builder.drug_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
+        measurement_sql = str(builder.measurement_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        observation_sql = str(builder.observation_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        condition_sql = str(builder.condition_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        drug_sql = str(builder.drug_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
 
         assert "measurement.person_id" in measurement_sql
         assert "observation.person_id" in observation_sql
         assert "condition_occurrence.person_id" in condition_sql
         assert "drug_exposure.person_id" in drug_sql
 
-    def test_add_numeric_range_with_valid_range(self) -> None:
+    def test_add_numeric_range_with_valid_range(self) -> None: 
         """Test adding a valid numeric range."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -309,17 +283,15 @@ class TestOMOPRuleQueryBuilder:
         builder.add_numeric_range()
 
         builder.add_numeric_range(10.5, 20.5)
-
-        measurement_sql = str(
-            builder.measurement_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-        observation_sql = str(
-            builder.observation_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
+        
+        measurement_sql = str(builder.measurement_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        observation_sql = str(builder.observation_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
 
         assert "value_as_number BETWEEN 10.5 AND 20.5" in measurement_sql
         assert "value_as_number BETWEEN 10.5 AND 20.5" in observation_sql
@@ -329,27 +301,25 @@ class TestOMOPRuleQueryBuilder:
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError): 
             builder.add_numeric_range(20.0, 10.0)
-
+        
     def test_add_secondary_modifiers_empty_list(self) -> None:
         """Test with empty list - no constraints should be added."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_secondary_modifiers([])
-
+        
         # Check all queries remain unchanged
-        condition_sql = str(
-            builder.condition_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-        measurement_sql = str(
-            builder.measurement_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
+        condition_sql = str(builder.condition_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        measurement_sql = str(builder.measurement_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
 
         assert "condition_type_concept_id" not in condition_sql
         assert "condition_type_concept_id" not in measurement_sql
@@ -362,27 +332,23 @@ class TestOMOPRuleQueryBuilder:
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_secondary_modifiers([32020])
-
-        condition_sql = str(
-            builder.condition_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-
+        
+        condition_sql = str(builder.condition_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
+        
         assert "condition_type_concept_id = 32020" in condition_sql
         assert " OR " not in condition_sql
-
-        measurement_sql = str(
-            builder.measurement_query.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
+        
+        measurement_sql = str(builder.measurement_query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True}
+        ))
         assert "condition_type_concept_id" not in measurement_sql
 
     @pytest.mark.parametrize("invalid_input", [None, 32020, "32020", {"id": 32020}])
-    def test_add_secondary_modifiers_invalid_input_type(
-        self, invalid_input: None | int | str | dict
-    ) -> None:
+    def test_add_secondary_modifiers_invalid_input_type(self, invalid_input: None | int | str | dict) -> None:
         """Test with invalid input types - should raise appropriate error."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -543,11 +509,11 @@ class TestOMOPRuleQueryBuilder:
 
         concept_id = 12345
         builder.add_concept_constraint(concept_id)
-
+        
         result = builder.build()
         compiled = result.compile(compile_kwargs={"literal_binds": True})
         query_str = str(compiled)
-
+        
         assert str(concept_id) in query_str
         assert "condition_concept_id" in query_str
         assert "measurement_concept_id" in query_str
@@ -560,9 +526,7 @@ class TestOMOPRuleQueryBuilder:
 
         builder.add_concept_constraint(12345)
 
-        specimen_sql = str(
-            builder.specimen_query.compile(compile_kwargs={"literal_binds": True})
-        )
+        specimen_sql = str(builder.specimen_query.compile(compile_kwargs={"literal_binds": True}))
         assert "specimen.specimen_concept_id = 12345" in specimen_sql
 
     def test_build_with_multiple_constraints(self) -> None:
@@ -572,15 +536,15 @@ class TestOMOPRuleQueryBuilder:
 
         builder.add_concept_constraint(12345)
         builder.add_numeric_range(5.0, 10.0)
-        builder.add_temporal_constraint("6", "")
-
+        builder.add_temporal_constraint("6", "")  
+        
         result = builder.build()
         compiled = result.compile(compile_kwargs={"literal_binds": True})
         query_str = str(compiled)
 
-        assert "12345" in query_str
-        assert "BETWEEN" in query_str
-        assert "measurement_date" in query_str
+        assert "12345" in query_str  
+        assert "BETWEEN" in query_str 
+        assert "measurement_date" in query_str 
         assert "UNION" in query_str
 
     def test_build_maintains_union_structure(self) -> None:
@@ -590,21 +554,19 @@ class TestOMOPRuleQueryBuilder:
 
         builder.add_concept_constraint(99999)
         builder.add_numeric_range(1.0, 100.0)
-
+        
         result = builder.build()
-
+        
         # Count UNION occurrences (should be 3 for 4 queries)
         query_str = str(result)
         union_count = query_str.count("UNION")
-
+        
         # 4 queries connected by 3 UNIONs
         assert union_count == 4
 
     def test_location_varcat_produces_person_location_join(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(
-            mock_db_manager, include_location=True, varcat="Location"
-        )
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
 
         query_str = str(builder.build())
 
@@ -619,9 +581,7 @@ class TestOMOPRuleQueryBuilder:
 
     def test_location_varcat_empty_value_no_where_clause(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(
-            mock_db_manager, include_location=True, varcat="Location"
-        )
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
         # No constraint added — empty secondary_modifier case
         query_str = str(builder.build())
         assert "location" in query_str
@@ -638,9 +598,7 @@ class TestOMOPRuleQueryBuilder:
 
     def test_location_varcat_explicitly_disabled_excludes_location(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(
-            mock_db_manager, include_location=False, varcat="Location"
-        )
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=False, varcat="Location")
 
         query_str = str(builder.build())
 
@@ -650,18 +608,14 @@ class TestOMOPRuleQueryBuilder:
         """add_haversine_radius_constraint adds distance and NULL guards to location_query."""
         mock_db_manager = Mock()
         mock_db_manager.engine.dialect.name = "duckdb"
-        builder = OMOPRuleQueryBuilder(
-            mock_db_manager, include_location=True, varcat="Location"
-        )
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
 
         builder.add_haversine_radius_constraint(51.5074, -0.1278, 5000.0)
 
-        query_str = str(
-            builder.build().compile(
-                dialect=postgresql.dialect(),
-                compile_kwargs={"literal_binds": True},
-            )
-        )
+        query_str = str(builder.build().compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        ))
         assert "latitude" in query_str
         assert "longitude" in query_str
         assert "asin" in query_str.lower() or "sin" in query_str.lower()
@@ -670,9 +624,7 @@ class TestOMOPRuleQueryBuilder:
         """add_haversine_radius_constraint adds IS NOT NULL guards for lat and lon."""
         mock_db_manager = Mock()
         mock_db_manager.engine.dialect.name = "postgresql"
-        builder = OMOPRuleQueryBuilder(
-            mock_db_manager, include_location=True, varcat="Location"
-        )
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
 
         builder.add_haversine_radius_constraint(0.0, 0.0, 1000.0)
 
@@ -693,7 +645,6 @@ class TestOMOPRuleQueryBuilder:
     def test_get_haversine_distance_unsupported_dialect_raises(self) -> None:
         """get_haversine_distance raises NotImplementedError for unsupported dialects."""
         from hutch_bunny.core.db.entities import Location
-
         engine = Mock()
         engine.dialect.name = "mysql"
 
@@ -703,7 +654,7 @@ class TestOMOPRuleQueryBuilder:
             )
 
 
-class TestPersonQueryConstraintBuilder:
+class TestPersonQueryConstraintBuilder: 
     @pytest.fixture
     def mock_db_manager(self) -> Mock:
         """Create a mock database manager."""
@@ -719,62 +670,51 @@ class TestPersonQueryConstraintBuilder:
         return PersonConstraintBuilder(mock_db_manager)
 
     def test_build_age_constraints_valid_range(
-        self, builder: PersonConstraintBuilder
+        self,
+        builder: PersonConstraintBuilder
     ) -> None:
         """Test age constraints produce correct SQL for a given range."""
         rule = Mock()
         rule.min_value = 18.0
         rule.max_value = 65.0
 
-        with patch(
-            "hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference"
-        ) as mock_diff:
+        with patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference") as mock_diff:
             mock_diff.return_value = literal_column("25")
             constraints = builder._build_age_constraints(rule)
 
         # Expect 1 constraint with AND inside
         assert len(constraints) == 1
 
-        compiled_sql = str(
-            constraints[0].compile(compile_kwargs={"literal_binds": True})
-        )
+        compiled_sql = str(constraints[0].compile(compile_kwargs={"literal_binds": True}))
 
         # Check both conditions are in the combined constraint
         assert f">= {rule.min_value}" in compiled_sql
         assert f"<= {rule.max_value}" in compiled_sql
 
-    def test_build_age_constraints_none_values(
-        self, builder: PersonConstraintBuilder
-    ) -> None:
+    def test_build_age_constraints_none_values(self, builder: PersonConstraintBuilder) -> None:
         """Directly test _build_age_constraints with None values."""
         rule = Mock()
         rule.min_value = None
         rule.max_value = 65.0
-
+        
         result = builder._build_age_constraints(rule)
-
+        
         assert result == []
 
-    def test_build_gender_constraint_with_inclusion(
-        self, builder: PersonConstraintBuilder
-    ) -> None:
+    def test_build_gender_constraint_with_inclusion(self, builder: PersonConstraintBuilder) -> None:
         """Test gender inclusion produces correct SQL."""
         rule = Mock()
         rule.value = "8507"
         rule.operator = "="
-        rule.greater_than_value = None
-        rule.less_than_value = None
+        rule.greater_than_value=None
+        rule.less_than_value=None
 
-        result = builder._build_gender_constraint(
-            rule, builder._build_age_constraint(rule)
-        )
+        result = builder._build_gender_constraint(rule, builder._build_age_constraint(rule))
         assert len(result) == 1
         compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
         assert compiled_sql == "person.gender_concept_id = 8507"
-
-    def test_build_gender_constraint_with_exclusion(
-        self, builder: PersonConstraintBuilder
-    ) -> None:
+    
+    def test_build_gender_constraint_with_exclusion(self, builder: PersonConstraintBuilder) -> None:
         """Test gender exclusion produces correct SQL."""
         rule = Mock()
         rule.value = "8532"
@@ -782,16 +722,12 @@ class TestPersonQueryConstraintBuilder:
         rule.greater_than_value = None
         rule.less_than_value = None
 
-        result = builder._build_gender_constraint(
-            rule, builder._build_age_constraint(rule)
-        )
+        result = builder._build_gender_constraint(rule, builder._build_age_constraint(rule))
         assert len(result) == 1
         compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
         assert compiled_sql == "person.gender_concept_id != 8532"
 
-    def test_build_gender_constraint_directly_invalid_value(
-        self, builder: PersonConstraintBuilder
-    ) -> None:
+    def test_build_gender_constraint_directly_invalid_value(self, builder: PersonConstraintBuilder) -> None:
         """Directly test _build_gender_constraint with invalid value."""
         rule = Mock()
         rule.value = "not_a_number"
@@ -815,16 +751,12 @@ class TestPersonQueryConstraintBuilder:
             rule.operator = operator
             rule.greater_than_value = None
             rule.less_than_value = None
-
-            result = builder._build_race_constraint(
-                rule, builder._build_age_constraint(rule)
-            )
+            
+            result = builder._build_race_constraint(rule, builder._build_age_constraint(rule))
             assert len(result) == 1
-            compiled_sql = str(
-                result[0].compile(compile_kwargs={"literal_binds": True})
-            )
+            compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
             assert compiled_sql == expected_sql
-
+    
     def test_build_ethnicity_constraint(self, builder: PersonConstraintBuilder) -> None:
         """Test ethnicity constraint for both inclusion and exclusion."""
         test_cases = [
@@ -839,61 +771,59 @@ class TestPersonQueryConstraintBuilder:
             rule.greater_than_value = None
             rule.less_than_value = None
 
-            result = builder._build_ethnicity_constraint(
-                rule, builder._build_age_constraint(rule)
-            )
+            result = builder._build_ethnicity_constraint(rule, builder._build_age_constraint(rule))
             assert len(result) == 1
-            compiled_sql = str(
-                result[0].compile(compile_kwargs={"literal_binds": True})
-            )
+            compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
             assert compiled_sql == expected_sql
 
     @pytest.mark.parametrize(
         "rule_setup, expected_sql_parts",
-        [
-            # Age rule (min/max)
-            (
-                {"varname": "AGE", "min_value": 18.0, "max_value": 65.0},
-                ["person.year_of_birth", ">=", "18.0"],
-            ),
-            # Gender inclusion
-            (
-                {"type": "gender", "value": "8507", "operator": "="},
-                ["person.gender_concept_id = 8507"],
-            ),
-            # Race exclusion
-            (
-                {"type": "race", "value": "8527", "operator": "!="},
-                ["person.race_concept_id != 8527"],
-            ),
-            # Ethnicity inclusion
-            (
-                {"type": "ethnicity", "value": "8100", "operator": "="},
-                ["person.ethnicity_concept_id = 8100"],
-            ),
-        ],
+            [
+                # Age rule (min/max)
+                (
+                    {"varname": "AGE", "min_value": 18.0, "max_value": 65.0},
+                    ["person.year_of_birth", ">=", "18.0"]
+                ),
+                # Gender inclusion
+                (
+                    {"type": "gender", "value": "8507", "operator": "="},
+                    ["person.gender_concept_id = 8507"]
+                ),
+                # Race exclusion
+                (
+                    {"type": "race", "value": "8527", "operator": "!="},
+                    ["person.race_concept_id != 8527"]
+                ),
+                # Ethnicity inclusion
+                (
+                    {"type": "ethnicity", "value": "8100", "operator": "="},
+                    ["person.ethnicity_concept_id = 8100"]
+                ),
+            ]
     )
     def test_build_constraints_single_rule(
-        self,
-        rule_setup: dict[str, str | float],
-        expected_sql_parts: list[str],
-        builder: PersonConstraintBuilder,
+        self, 
+        rule_setup: dict[str, str | float], 
+        expected_sql_parts: list[str], 
+        builder: PersonConstraintBuilder
     ) -> None:
         """Test build_constraints returns correct SQL for a single rule type."""
         rule = Mock(**rule_setup)
         rule.greater_than_value = None
         rule.less_than_value = None
 
-        concepts = {"8507": "Gender", "8527": "Race", "8100": "Ethnicity"}
+        concepts = {
+            "8507": "Gender", 
+            "8527": "Race", 
+            "8100": "Ethnicity"
+        }
 
         constraints = builder.build_constraints(rule, concepts)
 
         assert isinstance(constraints, list)
         assert len(constraints) >= 1
 
-        compiled_sql = str(
-            constraints[0].compile(compile_kwargs={"literal_binds": True})
-        )
+        compiled_sql = str(constraints[0].compile(compile_kwargs={"literal_binds": True}))
 
         # Check expected SQL fragments or exact match
         for part in expected_sql_parts:

--- a/tests/unit/solvers/test_rule_query_builders.py
+++ b/tests/unit/solvers/test_rule_query_builders.py
@@ -7,23 +7,27 @@ from sqlalchemy.sql import CompoundSelect
 from sqlalchemy.sql.elements import literal_column
 from sqlalchemy.dialects import postgresql
 
-from hutch_bunny.core.solvers.rule_query_builders import SQLDialectHandler, OMOPRuleQueryBuilder, PersonConstraintBuilder
+from hutch_bunny.core.solvers.rule_query_builders import (
+    SQLDialectHandler,
+    OMOPRuleQueryBuilder,
+    PersonConstraintBuilder,
+)
 
 
 class TestSQLDialectHandler:
-
     def test_get_year_difference_unsupported_dialect(self) -> None:
         """Test that an unsupported dialect raises NotImplementedError."""
         metadata = MetaData()
         test_table = Table(
-            "test", metadata,
+            "test",
+            metadata,
             Column("start_date", Date),
             Column("birth_date", Date),
         )
 
         # Mock engine with unsupported dialect name
         engine = Mock()
-        engine.dialect.name = "mysql"  
+        engine.dialect.name = "mysql"
 
         start_date = test_table.c.start_date
         birth_date = test_table.c.birth_date
@@ -38,7 +42,8 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test", metadata,
+            "test",
+            metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -46,11 +51,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
-
-        assert str(result) == str(
-            func.date_part("year", start_date) - year_of_birth
+        result = SQLDialectHandler.get_year_difference(
+            engine, start_date, year_of_birth
         )
+
+        assert str(result) == str(func.date_part("year", start_date) - year_of_birth)
 
     def test_get_year_difference_duckdb(self) -> None:
         """Test DuckDB dialect returns correct function."""
@@ -59,7 +64,8 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test", metadata,
+            "test",
+            metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -67,11 +73,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
-
-        assert str(result) == str(
-            func.date_part("year", start_date) - year_of_birth
+        result = SQLDialectHandler.get_year_difference(
+            engine, start_date, year_of_birth
         )
+
+        assert str(result) == str(func.date_part("year", start_date) - year_of_birth)
 
     def test_get_year_difference_mssql(self) -> None:
         """Test MSSQL dialect returns correct function."""
@@ -80,7 +86,8 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test", metadata,
+            "test",
+            metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -88,7 +95,9 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
+        result = SQLDialectHandler.get_year_difference(
+            engine, start_date, year_of_birth
+        )
 
         assert str(result) == str(
             func.DATEPART(text("year"), start_date) - year_of_birth
@@ -101,7 +110,8 @@ class TestSQLDialectHandler:
 
         metadata = MetaData()
         test_table = Table(
-            "test", metadata,
+            "test",
+            metadata,
             Column("start_date", Date),
             Column("year_of_birth", Date),
         )
@@ -109,11 +119,11 @@ class TestSQLDialectHandler:
         start_date = test_table.c.start_date
         year_of_birth = test_table.c.year_of_birth
 
-        result = SQLDialectHandler.get_year_difference(engine, start_date, year_of_birth)
+        result = SQLDialectHandler.get_year_difference(
+            engine, start_date, year_of_birth
+        )
 
-        assert str(result) == str(
-            func.YEAR(start_date) - year_of_birth)
-
+        assert str(result) == str(func.YEAR(start_date) - year_of_birth)
 
     def test_get_year_difference_with_actual_column_elements(self) -> None:
         """Test with actual SQLAlchemy column elements."""
@@ -123,7 +133,7 @@ class TestSQLDialectHandler:
         Base = declarative_base()
 
         class TestTable(Base):
-            __tablename__ = 'test'
+            __tablename__ = "test"
             id = Column(Integer, primary_key=True)
             start_date = Column(Date)
             birth_date = Column(Date)
@@ -131,22 +141,20 @@ class TestSQLDialectHandler:
         # Test with PostgreSQL
         pg_engine = create_engine("postgresql+psycopg://user:pass@localhost/db")
         result = SQLDialectHandler.get_year_difference(
-            pg_engine,
-            TestTable.start_date,
-            TestTable.birth_date
+            pg_engine, TestTable.start_date, TestTable.birth_date
         )
 
         # Verify it produces valid SQL when compiled
-        compiled = str(result.compile(
-            dialect=postgresql.dialect(), 
-            compile_kwargs={"literal_binds": True}
-        ))
+        compiled = str(
+            result.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
         assert "date_part" in compiled
         assert "year" in compiled
 
 
-class TestOMOPRuleQueryBuilder():
-    
+class TestOMOPRuleQueryBuilder:
     def test_add_concept_constraint(self) -> None:
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -154,12 +162,16 @@ class TestOMOPRuleQueryBuilder():
         concept_id = 111
         builder.add_concept_constraint(concept_id)
 
-        compiled = builder.condition_query.compile(compile_kwargs={"literal_binds": True})
+        compiled = builder.condition_query.compile(
+            compile_kwargs={"literal_binds": True}
+        )
         sql_str = str(compiled)
 
         assert "WHERE condition_occurrence.condition_concept_id = 111" in sql_str
 
-    @patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference")
+    @patch(
+        "hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference"
+    )
     def test_add_age_constraint(self, mock_get_year_diff: Mock) -> None:
         mock_get_year_diff.return_value = literal_column("25")
 
@@ -168,12 +180,14 @@ class TestOMOPRuleQueryBuilder():
 
         builder.add_age_constraint("20", "")  # age > 20
 
-        compiled = builder.condition_query.compile(compile_kwargs={"literal_binds": True})
+        compiled = builder.condition_query.compile(
+            compile_kwargs={"literal_binds": True}
+        )
         sql_str = str(compiled)
 
         assert "25 >= 20" in sql_str
 
-    def test_add_temporal_constraint_only_left_constraint_present(self) -> None: 
+    def test_add_temporal_constraint_only_left_constraint_present(self) -> None:
         greater_than_value = "1"
         less_than_value = ""
 
@@ -183,15 +197,19 @@ class TestOMOPRuleQueryBuilder():
         relative_date = fixed_now + relativedelta(months=time_to_use)
 
         expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
-        expected_sql_fragment = f"condition_occurrence.condition_start_date <= '{expected_date_str}'"
+        expected_sql_fragment = (
+            f"condition_occurrence.condition_start_date <= '{expected_date_str}'"
+        )
 
-        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime: 
+        with patch(
+            "hutch_bunny.core.solvers.rule_query_builders.datetime"
+        ) as mock_datetime:
             mock_datetime.now.return_value = fixed_now
 
             mock_db_manager = Mock()
             builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-            builder.add_temporal_constraint(greater_than_value, less_than_value )
+            builder.add_temporal_constraint(greater_than_value, less_than_value)
 
             compiled = builder.condition_query.compile(
                 compile_kwargs={"literal_binds": True}
@@ -199,8 +217,8 @@ class TestOMOPRuleQueryBuilder():
             sql_str = str(compiled)
 
             assert expected_sql_fragment in sql_str
-    
-    def test_add_temporal_constraint_only_right_constraint_present(self) -> None: 
+
+    def test_add_temporal_constraint_only_right_constraint_present(self) -> None:
         greater_than_value = ""
         less_than_value = "1"
 
@@ -210,9 +228,13 @@ class TestOMOPRuleQueryBuilder():
         relative_date = fixed_now + relativedelta(months=time_to_use)
 
         expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
-        expected_sql_fragment = f"condition_occurrence.condition_start_date >= '{expected_date_str}'"
+        expected_sql_fragment = (
+            f"condition_occurrence.condition_start_date >= '{expected_date_str}'"
+        )
 
-        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime: 
+        with patch(
+            "hutch_bunny.core.solvers.rule_query_builders.datetime"
+        ) as mock_datetime:
             mock_datetime.now.return_value = fixed_now
 
             mock_db_manager = Mock()
@@ -227,55 +249,59 @@ class TestOMOPRuleQueryBuilder():
 
             assert expected_sql_fragment in sql_str
 
-    def test_add_temporal_constraint_no_input(self) -> None: 
+    def test_add_temporal_constraint_no_input(self) -> None:
         greater_than_value = ""
         less_than_value = ""
 
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError): 
+        with pytest.raises(ValueError):
             builder.add_temporal_constraint(greater_than_value, less_than_value)
-    
-    def test_add_temporal_constraint_both_inputs(self) -> None: 
+
+    def test_add_temporal_constraint_both_inputs(self) -> None:
         greater_than_value = "1"
         less_than_value = "2"
 
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError): 
+        with pytest.raises(ValueError):
             builder.add_temporal_constraint(greater_than_value, less_than_value)
 
-    def test_add_numeric_range_with_no_input(self) -> None: 
+    def test_add_numeric_range_with_no_input(self) -> None:
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_numeric_range()
 
-        measurement_sql = str(builder.measurement_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        observation_sql = str(builder.observation_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        condition_sql = str(builder.condition_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        drug_sql = str(builder.drug_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
+        measurement_sql = str(
+            builder.measurement_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        observation_sql = str(
+            builder.observation_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        condition_sql = str(
+            builder.condition_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        drug_sql = str(
+            builder.drug_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
 
         assert "measurement.person_id" in measurement_sql
         assert "observation.person_id" in observation_sql
         assert "condition_occurrence.person_id" in condition_sql
         assert "drug_exposure.person_id" in drug_sql
 
-    def test_add_numeric_range_with_valid_range(self) -> None: 
+    def test_add_numeric_range_with_valid_range(self) -> None:
         """Test adding a valid numeric range."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -283,15 +309,17 @@ class TestOMOPRuleQueryBuilder():
         builder.add_numeric_range()
 
         builder.add_numeric_range(10.5, 20.5)
-        
-        measurement_sql = str(builder.measurement_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        observation_sql = str(builder.observation_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
+
+        measurement_sql = str(
+            builder.measurement_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        observation_sql = str(
+            builder.observation_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
 
         assert "value_as_number BETWEEN 10.5 AND 20.5" in measurement_sql
         assert "value_as_number BETWEEN 10.5 AND 20.5" in observation_sql
@@ -301,25 +329,27 @@ class TestOMOPRuleQueryBuilder():
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
-        with pytest.raises(ValueError): 
+        with pytest.raises(ValueError):
             builder.add_numeric_range(20.0, 10.0)
-        
+
     def test_add_secondary_modifiers_empty_list(self) -> None:
         """Test with empty list - no constraints should be added."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_secondary_modifiers([])
-        
+
         # Check all queries remain unchanged
-        condition_sql = str(builder.condition_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        measurement_sql = str(builder.measurement_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
+        condition_sql = str(
+            builder.condition_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        measurement_sql = str(
+            builder.measurement_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
 
         assert "condition_type_concept_id" not in condition_sql
         assert "condition_type_concept_id" not in measurement_sql
@@ -332,23 +362,27 @@ class TestOMOPRuleQueryBuilder():
         builder = OMOPRuleQueryBuilder(mock_db_manager)
 
         builder.add_secondary_modifiers([32020])
-        
-        condition_sql = str(builder.condition_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
-        
+
+        condition_sql = str(
+            builder.condition_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+
         assert "condition_type_concept_id = 32020" in condition_sql
         assert " OR " not in condition_sql
-        
-        measurement_sql = str(builder.measurement_query.compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True}
-        ))
+
+        measurement_sql = str(
+            builder.measurement_query.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
         assert "condition_type_concept_id" not in measurement_sql
 
     @pytest.mark.parametrize("invalid_input", [None, 32020, "32020", {"id": 32020}])
-    def test_add_secondary_modifiers_invalid_input_type(self, invalid_input: None | int | str | dict) -> None:
+    def test_add_secondary_modifiers_invalid_input_type(
+        self, invalid_input: None | int | str | dict
+    ) -> None:
         """Test with invalid input types - should raise appropriate error."""
         mock_db_manager = Mock()
         builder = OMOPRuleQueryBuilder(mock_db_manager)
@@ -398,7 +432,9 @@ class TestOMOPRuleQueryBuilder():
 
     def test_build_includes_death_when_feature_enabled(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_death=True, varcat="Death"
+        )
 
         query_str = str(builder.build())
 
@@ -407,7 +443,9 @@ class TestOMOPRuleQueryBuilder():
     def test_death_varcat_bypasses_union_with_clinical_tables(self) -> None:
         """A Death rule should only ever query the death table, mirroring Location's bypass."""
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_death=True, varcat="Death"
+        )
 
         query_str = str(builder.build())
 
@@ -418,10 +456,14 @@ class TestOMOPRuleQueryBuilder():
         assert "drug_exposure.person_id" not in query_str
         assert "procedure_occurrence.person_id" not in query_str
 
-    def test_non_death_varcat_does_not_query_death_table_even_when_enabled(self) -> None:
+    def test_non_death_varcat_does_not_query_death_table_even_when_enabled(
+        self,
+    ) -> None:
         """A Condition rule must not silently also check the death table's cause_concept_id."""
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Condition")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_death=True, varcat="Condition"
+        )
 
         builder.add_concept_constraint(12345)
 
@@ -431,11 +473,15 @@ class TestOMOPRuleQueryBuilder():
 
     def test_add_concept_constraint_applies_to_death_when_enabled(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_death=True, varcat="Death"
+        )
 
         builder.add_concept_constraint(12345)
 
-        death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+        death_sql = str(
+            builder.death_query.compile(compile_kwargs={"literal_binds": True})
+        )
         assert "death.cause_concept_id = 12345" in death_sql
 
     def test_add_concept_constraint_does_not_apply_to_death_when_disabled(self) -> None:
@@ -446,17 +492,26 @@ class TestOMOPRuleQueryBuilder():
 
         assert builder.death_query is None
 
-    @patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference")
-    def test_add_age_constraint_applies_to_death_when_enabled(self, mock_get_year_diff: Mock) -> None:
+    @patch(
+        "hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference"
+    )
+    def test_add_age_constraint_applies_to_death_when_enabled(
+        self, mock_get_year_diff: Mock
+    ) -> None:
         from sqlalchemy.sql.elements import literal_column
+
         mock_get_year_diff.return_value = literal_column("25")
 
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_death=True, varcat="Death"
+        )
 
         builder.add_age_constraint("20", "")
 
-        death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+        death_sql = str(
+            builder.death_query.compile(compile_kwargs={"literal_binds": True})
+        )
         assert "25 >= 20" in death_sql
 
     def test_add_temporal_constraint_applies_to_death_when_enabled(self) -> None:
@@ -464,15 +519,21 @@ class TestOMOPRuleQueryBuilder():
         relative_date = fixed_now + relativedelta(months=-1)
         expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
 
-        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime:
+        with patch(
+            "hutch_bunny.core.solvers.rule_query_builders.datetime"
+        ) as mock_datetime:
             mock_datetime.now.return_value = fixed_now
 
             mock_db_manager = Mock()
-            builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+            builder = OMOPRuleQueryBuilder(
+                mock_db_manager, include_death=True, varcat="Death"
+            )
 
             builder.add_temporal_constraint("", "1")
 
-            death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+            death_sql = str(
+                builder.death_query.compile(compile_kwargs={"literal_binds": True})
+            )
             assert f"death.death_date >= '{expected_date_str}'" in death_sql
 
     def test_build_after_adding_concept_constraint(self) -> None:
@@ -482,11 +543,11 @@ class TestOMOPRuleQueryBuilder():
 
         concept_id = 12345
         builder.add_concept_constraint(concept_id)
-        
+
         result = builder.build()
         compiled = result.compile(compile_kwargs={"literal_binds": True})
         query_str = str(compiled)
-        
+
         assert str(concept_id) in query_str
         assert "condition_concept_id" in query_str
         assert "measurement_concept_id" in query_str
@@ -499,7 +560,9 @@ class TestOMOPRuleQueryBuilder():
 
         builder.add_concept_constraint(12345)
 
-        specimen_sql = str(builder.specimen_query.compile(compile_kwargs={"literal_binds": True}))
+        specimen_sql = str(
+            builder.specimen_query.compile(compile_kwargs={"literal_binds": True})
+        )
         assert "specimen.specimen_concept_id = 12345" in specimen_sql
 
     def test_build_with_multiple_constraints(self) -> None:
@@ -509,15 +572,15 @@ class TestOMOPRuleQueryBuilder():
 
         builder.add_concept_constraint(12345)
         builder.add_numeric_range(5.0, 10.0)
-        builder.add_temporal_constraint("6", "")  
-        
+        builder.add_temporal_constraint("6", "")
+
         result = builder.build()
         compiled = result.compile(compile_kwargs={"literal_binds": True})
         query_str = str(compiled)
 
-        assert "12345" in query_str  
-        assert "BETWEEN" in query_str 
-        assert "measurement_date" in query_str 
+        assert "12345" in query_str
+        assert "BETWEEN" in query_str
+        assert "measurement_date" in query_str
         assert "UNION" in query_str
 
     def test_build_maintains_union_structure(self) -> None:
@@ -539,7 +602,9 @@ class TestOMOPRuleQueryBuilder():
 
     def test_location_varcat_produces_person_location_join(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_location=True, varcat="Location"
+        )
 
         query_str = str(builder.build())
 
@@ -554,7 +619,9 @@ class TestOMOPRuleQueryBuilder():
 
     def test_location_varcat_empty_value_no_where_clause(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_location=True, varcat="Location"
+        )
         # No constraint added — empty secondary_modifier case
         query_str = str(builder.build())
         assert "location" in query_str
@@ -571,7 +638,9 @@ class TestOMOPRuleQueryBuilder():
 
     def test_location_varcat_explicitly_disabled_excludes_location(self) -> None:
         mock_db_manager = Mock()
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=False, varcat="Location")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_location=False, varcat="Location"
+        )
 
         query_str = str(builder.build())
 
@@ -581,11 +650,18 @@ class TestOMOPRuleQueryBuilder():
         """add_haversine_radius_constraint adds distance and NULL guards to location_query."""
         mock_db_manager = Mock()
         mock_db_manager.engine.dialect.name = "duckdb"
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_location=True, varcat="Location"
+        )
 
         builder.add_haversine_radius_constraint(51.5074, -0.1278, 5000.0)
 
-        query_str = str(builder.build())
+        query_str = str(
+            builder.build().compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
         assert "latitude" in query_str
         assert "longitude" in query_str
         assert "asin" in query_str.lower() or "sin" in query_str.lower()
@@ -594,7 +670,9 @@ class TestOMOPRuleQueryBuilder():
         """add_haversine_radius_constraint adds IS NOT NULL guards for lat and lon."""
         mock_db_manager = Mock()
         mock_db_manager.engine.dialect.name = "postgresql"
-        builder = OMOPRuleQueryBuilder(mock_db_manager, include_location=True, varcat="Location")
+        builder = OMOPRuleQueryBuilder(
+            mock_db_manager, include_location=True, varcat="Location"
+        )
 
         builder.add_haversine_radius_constraint(0.0, 0.0, 1000.0)
 
@@ -615,6 +693,7 @@ class TestOMOPRuleQueryBuilder():
     def test_get_haversine_distance_unsupported_dialect_raises(self) -> None:
         """get_haversine_distance raises NotImplementedError for unsupported dialects."""
         from hutch_bunny.core.db.entities import Location
+
         engine = Mock()
         engine.dialect.name = "mysql"
 
@@ -624,7 +703,7 @@ class TestOMOPRuleQueryBuilder():
             )
 
 
-class TestPersonQueryConstraintBuilder: 
+class TestPersonQueryConstraintBuilder:
     @pytest.fixture
     def mock_db_manager(self) -> Mock:
         """Create a mock database manager."""
@@ -640,51 +719,62 @@ class TestPersonQueryConstraintBuilder:
         return PersonConstraintBuilder(mock_db_manager)
 
     def test_build_age_constraints_valid_range(
-        self,
-        builder: PersonConstraintBuilder
+        self, builder: PersonConstraintBuilder
     ) -> None:
         """Test age constraints produce correct SQL for a given range."""
         rule = Mock()
         rule.min_value = 18.0
         rule.max_value = 65.0
 
-        with patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference") as mock_diff:
+        with patch(
+            "hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference"
+        ) as mock_diff:
             mock_diff.return_value = literal_column("25")
             constraints = builder._build_age_constraints(rule)
 
         # Expect 1 constraint with AND inside
         assert len(constraints) == 1
 
-        compiled_sql = str(constraints[0].compile(compile_kwargs={"literal_binds": True}))
+        compiled_sql = str(
+            constraints[0].compile(compile_kwargs={"literal_binds": True})
+        )
 
         # Check both conditions are in the combined constraint
         assert f">= {rule.min_value}" in compiled_sql
         assert f"<= {rule.max_value}" in compiled_sql
 
-    def test_build_age_constraints_none_values(self, builder: PersonConstraintBuilder) -> None:
+    def test_build_age_constraints_none_values(
+        self, builder: PersonConstraintBuilder
+    ) -> None:
         """Directly test _build_age_constraints with None values."""
         rule = Mock()
         rule.min_value = None
         rule.max_value = 65.0
-        
+
         result = builder._build_age_constraints(rule)
-        
+
         assert result == []
 
-    def test_build_gender_constraint_with_inclusion(self, builder: PersonConstraintBuilder) -> None:
+    def test_build_gender_constraint_with_inclusion(
+        self, builder: PersonConstraintBuilder
+    ) -> None:
         """Test gender inclusion produces correct SQL."""
         rule = Mock()
         rule.value = "8507"
         rule.operator = "="
-        rule.greater_than_value=None
-        rule.less_than_value=None
+        rule.greater_than_value = None
+        rule.less_than_value = None
 
-        result = builder._build_gender_constraint(rule, builder._build_age_constraint(rule))
+        result = builder._build_gender_constraint(
+            rule, builder._build_age_constraint(rule)
+        )
         assert len(result) == 1
         compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
         assert compiled_sql == "person.gender_concept_id = 8507"
-    
-    def test_build_gender_constraint_with_exclusion(self, builder: PersonConstraintBuilder) -> None:
+
+    def test_build_gender_constraint_with_exclusion(
+        self, builder: PersonConstraintBuilder
+    ) -> None:
         """Test gender exclusion produces correct SQL."""
         rule = Mock()
         rule.value = "8532"
@@ -692,12 +782,16 @@ class TestPersonQueryConstraintBuilder:
         rule.greater_than_value = None
         rule.less_than_value = None
 
-        result = builder._build_gender_constraint(rule, builder._build_age_constraint(rule))
+        result = builder._build_gender_constraint(
+            rule, builder._build_age_constraint(rule)
+        )
         assert len(result) == 1
         compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
         assert compiled_sql == "person.gender_concept_id != 8532"
 
-    def test_build_gender_constraint_directly_invalid_value(self, builder: PersonConstraintBuilder) -> None:
+    def test_build_gender_constraint_directly_invalid_value(
+        self, builder: PersonConstraintBuilder
+    ) -> None:
         """Directly test _build_gender_constraint with invalid value."""
         rule = Mock()
         rule.value = "not_a_number"
@@ -721,12 +815,16 @@ class TestPersonQueryConstraintBuilder:
             rule.operator = operator
             rule.greater_than_value = None
             rule.less_than_value = None
-            
-            result = builder._build_race_constraint(rule, builder._build_age_constraint(rule))
+
+            result = builder._build_race_constraint(
+                rule, builder._build_age_constraint(rule)
+            )
             assert len(result) == 1
-            compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
+            compiled_sql = str(
+                result[0].compile(compile_kwargs={"literal_binds": True})
+            )
             assert compiled_sql == expected_sql
-    
+
     def test_build_ethnicity_constraint(self, builder: PersonConstraintBuilder) -> None:
         """Test ethnicity constraint for both inclusion and exclusion."""
         test_cases = [
@@ -741,59 +839,61 @@ class TestPersonQueryConstraintBuilder:
             rule.greater_than_value = None
             rule.less_than_value = None
 
-            result = builder._build_ethnicity_constraint(rule, builder._build_age_constraint(rule))
+            result = builder._build_ethnicity_constraint(
+                rule, builder._build_age_constraint(rule)
+            )
             assert len(result) == 1
-            compiled_sql = str(result[0].compile(compile_kwargs={"literal_binds": True}))
+            compiled_sql = str(
+                result[0].compile(compile_kwargs={"literal_binds": True})
+            )
             assert compiled_sql == expected_sql
 
     @pytest.mark.parametrize(
         "rule_setup, expected_sql_parts",
-            [
-                # Age rule (min/max)
-                (
-                    {"varname": "AGE", "min_value": 18.0, "max_value": 65.0},
-                    ["person.year_of_birth", ">=", "18.0"]
-                ),
-                # Gender inclusion
-                (
-                    {"type": "gender", "value": "8507", "operator": "="},
-                    ["person.gender_concept_id = 8507"]
-                ),
-                # Race exclusion
-                (
-                    {"type": "race", "value": "8527", "operator": "!="},
-                    ["person.race_concept_id != 8527"]
-                ),
-                # Ethnicity inclusion
-                (
-                    {"type": "ethnicity", "value": "8100", "operator": "="},
-                    ["person.ethnicity_concept_id = 8100"]
-                ),
-            ]
+        [
+            # Age rule (min/max)
+            (
+                {"varname": "AGE", "min_value": 18.0, "max_value": 65.0},
+                ["person.year_of_birth", ">=", "18.0"],
+            ),
+            # Gender inclusion
+            (
+                {"type": "gender", "value": "8507", "operator": "="},
+                ["person.gender_concept_id = 8507"],
+            ),
+            # Race exclusion
+            (
+                {"type": "race", "value": "8527", "operator": "!="},
+                ["person.race_concept_id != 8527"],
+            ),
+            # Ethnicity inclusion
+            (
+                {"type": "ethnicity", "value": "8100", "operator": "="},
+                ["person.ethnicity_concept_id = 8100"],
+            ),
+        ],
     )
     def test_build_constraints_single_rule(
-        self, 
-        rule_setup: dict[str, str | float], 
-        expected_sql_parts: list[str], 
-        builder: PersonConstraintBuilder
+        self,
+        rule_setup: dict[str, str | float],
+        expected_sql_parts: list[str],
+        builder: PersonConstraintBuilder,
     ) -> None:
         """Test build_constraints returns correct SQL for a single rule type."""
         rule = Mock(**rule_setup)
         rule.greater_than_value = None
         rule.less_than_value = None
 
-        concepts = {
-            "8507": "Gender", 
-            "8527": "Race", 
-            "8100": "Ethnicity"
-        }
+        concepts = {"8507": "Gender", "8527": "Race", "8100": "Ethnicity"}
 
         constraints = builder.build_constraints(rule, concepts)
 
         assert isinstance(constraints, list)
         assert len(constraints) >= 1
 
-        compiled_sql = str(constraints[0].compile(compile_kwargs={"literal_binds": True}))
+        compiled_sql = str(
+            constraints[0].compile(compile_kwargs={"literal_binds": True})
+        )
 
         # Check expected SQL fragments or exact match
         for part in expected_sql_parts:

--- a/tests/unit/solvers/test_rule_query_builders.py
+++ b/tests/unit/solvers/test_rule_query_builders.py
@@ -388,6 +388,93 @@ class TestOMOPRuleQueryBuilder():
 
         assert "specimen.person_id" in query_str
 
+    def test_build_does_not_include_death_when_feature_disabled(self) -> None:
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, varcat="Death")
+
+        query_str = str(builder.build())
+
+        assert "death.person_id" not in query_str
+
+    def test_build_includes_death_when_feature_enabled(self) -> None:
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+
+        query_str = str(builder.build())
+
+        assert "death.person_id" in query_str
+
+    def test_death_varcat_bypasses_union_with_clinical_tables(self) -> None:
+        """A Death rule should only ever query the death table, mirroring Location's bypass."""
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+
+        query_str = str(builder.build())
+
+        assert "death.person_id" in query_str
+        assert "measurement.person_id" not in query_str
+        assert "observation.person_id" not in query_str
+        assert "condition_occurrence.person_id" not in query_str
+        assert "drug_exposure.person_id" not in query_str
+        assert "procedure_occurrence.person_id" not in query_str
+
+    def test_non_death_varcat_does_not_query_death_table_even_when_enabled(self) -> None:
+        """A Condition rule must not silently also check the death table's cause_concept_id."""
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Condition")
+
+        builder.add_concept_constraint(12345)
+
+        assert builder.death_query is None
+        query_str = str(builder.build())
+        assert "death.person_id" not in query_str
+
+    def test_add_concept_constraint_applies_to_death_when_enabled(self) -> None:
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+
+        builder.add_concept_constraint(12345)
+
+        death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+        assert "death.cause_concept_id = 12345" in death_sql
+
+    def test_add_concept_constraint_does_not_apply_to_death_when_disabled(self) -> None:
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, varcat="Death")
+
+        builder.add_concept_constraint(12345)
+
+        assert builder.death_query is None
+
+    @patch("hutch_bunny.core.solvers.rule_query_builders.SQLDialectHandler.get_year_difference")
+    def test_add_age_constraint_applies_to_death_when_enabled(self, mock_get_year_diff: Mock) -> None:
+        from sqlalchemy.sql.elements import literal_column
+        mock_get_year_diff.return_value = literal_column("25")
+
+        mock_db_manager = Mock()
+        builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+
+        builder.add_age_constraint("20", "")
+
+        death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+        assert "25 >= 20" in death_sql
+
+    def test_add_temporal_constraint_applies_to_death_when_enabled(self) -> None:
+        fixed_now = datetime(2025, 8, 7, 12, 0, 0)
+        relative_date = fixed_now + relativedelta(months=-1)
+        expected_date_str = relative_date.strftime("%Y-%m-%d %H:%M:%S")
+
+        with patch("hutch_bunny.core.solvers.rule_query_builders.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+
+            mock_db_manager = Mock()
+            builder = OMOPRuleQueryBuilder(mock_db_manager, include_death=True, varcat="Death")
+
+            builder.add_temporal_constraint("", "1")
+
+            death_sql = str(builder.death_query.compile(compile_kwargs={"literal_binds": True}))
+            assert f"death.death_date >= '{expected_date_str}'" in death_sql
+
     def test_build_after_adding_concept_constraint(self) -> None:
         """Test build after adding a concept constraint."""
         mock_db_manager = Mock()
@@ -440,13 +527,13 @@ class TestOMOPRuleQueryBuilder():
 
         builder.add_concept_constraint(99999)
         builder.add_numeric_range(1.0, 100.0)
-        
+
         result = builder.build()
-        
+
         # Count UNION occurrences (should be 3 for 4 queries)
         query_str = str(result)
         union_count = query_str.count("UNION")
-        
+
         # 4 queries connected by 3 UNIONs
         assert union_count == 4
 
@@ -498,10 +585,7 @@ class TestOMOPRuleQueryBuilder():
 
         builder.add_haversine_radius_constraint(51.5074, -0.1278, 5000.0)
 
-        query_str = str(builder.build().compile(
-            dialect=postgresql.dialect(),
-            compile_kwargs={"literal_binds": True},
-        ))
+        query_str = str(builder.build())
         assert "latitude" in query_str
         assert "longitude" in query_str
         assert "asin" in query_str.lower() or "sin" in query_str.lower()


### PR DESCRIPTION
✨ Feature

## PR Description

### Adding OMOP Death table support

Bunny can now resolve availability (and distribution) queries against the OMOP CDM `death` table.

Given a `varcat` of `Death` in a rule:
- An empty `value` with `oper: "="` matches every person with a row in `death` (i.e. anyone recorded as deceased), with no cause filter applied.
- A non-empty `value` filters on `death.cause_concept_id` (cause-of-death), e.g. `{"varcat": "Death", "oper": "=", "value": "4329847"}`.
- `oper: "!="` inverts the same underlying "has a death row" query into an exclusion — e.g. an empty value with `!=` selects the living.
- Age-at-event (`death.death_date` vs `person.year_of_birth`) and temporal window constraints against `death.death_date` are also supported.

Gated behind `OMOP_DEATH_ENABLED`, defaulting to `false`. When disabled, a Death rule contributes zero matches (or, for a `!=` exclusion, matches everyone) rather than erroring — the same fallback pattern used for `OMOP_LOCATION_ENABLED`/`OMOP_SPECIMEN_ENABLED`.

Death has no per-person clinical event table to union with condition/drug/measurement/observation/procedure, so — mirroring `Location` — a `varcat` of `Death` bypasses `OMOPRuleQueryBuilder`'s usual UNION entirely and targets the `death` table alone.

Distribution queries were also updated (`distribution_solver.py`) to recognise the `Death` domain and respect the same `OMOP_DEATH_ENABLED` flag.

## Related Issues or other material
Closes #260

## Screenshots, example outputs/behaviour etc.

Example availability query (`tests/queries/availability/death_any.json`) — "has any death record":
```json
{
  "varname": "OMOP",
  "varcat": "Death",
  "type": "TEXT",
  "oper": "=",
  "value": ""
}
```

You can also exclude with `!=` or pass a value that is the `cause_concept_id`


## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

Added:
- Unit tests for `OMOPRuleQueryBuilder` Death handling — concept/age/temporal constraints, union bypass, feature-flag on/off (`tests/unit/solvers/test_rule_query_builders.py`)
- Unit tests for the `OMOP_DEATH_ENABLED` setting (`tests/unit/core/test_settings.py`)
- End-to-end CLI tests covering enabled/disabled behaviour for all four Death query fixtures (`tests/end_to_end/test_cli_death.py`)
